### PR TITLE
Refactoring: move `opencorActive()` to core GUI utilities.

### DIFF
--- a/src/plugins/miscellaneous/Core/src/coreguiutils.cpp
+++ b/src/plugins/miscellaneous/Core/src/coreguiutils.cpp
@@ -639,6 +639,21 @@ QStringList filters(const FileTypes &pFileTypes, const QStringList &pMimeTypes)
 
 //==============================================================================
 
+bool opencorActive()
+{
+    // Return whether OpenCOR is active
+    // Note: we only consider OpenCOR to be active if the main window or one of
+    //       its dockable windows is active. In other words, if a dialog box is
+    //       opened, then we don't consider OpenCOR active since it could
+    //       disturb our user's workflow...
+
+    return     qApp->activeWindow()
+           && !qApp->activeModalWidget()
+           && !qApp->activePopupWidget();
+}
+
+//==============================================================================
+
 }   // namespace Core
 }   // namespace OpenCOR
 

--- a/src/plugins/miscellaneous/Core/src/coreguiutils.h
+++ b/src/plugins/miscellaneous/Core/src/coreguiutils.h
@@ -121,6 +121,8 @@ QStringList CORE_EXPORT filters(const FileTypes &pFileTypes);
 QStringList CORE_EXPORT filters(const FileTypes &pFileTypes,
                                 const QStringList &pMimeTypes);
 
+bool CORE_EXPORT opencorActive();
+
 //==============================================================================
 
 }   // namespace Core

--- a/src/plugins/miscellaneous/Core/src/filemanager.cpp
+++ b/src/plugins/miscellaneous/Core/src/filemanager.cpp
@@ -78,21 +78,6 @@ FileManager::~FileManager()
 
 //==============================================================================
 
-bool FileManager::opencorActive() const
-{
-    // Return whether OpenCOR is active
-    // Note: we only consider OpenCOR to be active if the main window or one of
-    //       its dockable windows is active. In other words, if a dialog box is
-    //       opened, then we don't consider OpenCOR active since it could
-    //       disturb our user's workflow...
-
-    return     qApp->activeWindow()
-           && !qApp->activeModalWidget()
-           && !qApp->activePopupWidget();
-}
-
-//==============================================================================
-
 void FileManager::startStopTimer()
 {
     // Start our timer if OpenCOR is active and we have files, or stop it if
@@ -105,7 +90,7 @@ void FileManager::startStopTimer()
     //          handle that signal would result in reentry, so we temporarily
     //          disable our handling of it...
 
-    if (opencorActive() && !mFiles.isEmpty() && !mTimer->isActive()) {
+    if (Core::opencorActive() && !mFiles.isEmpty() && !mTimer->isActive()) {
         disconnect(qApp, SIGNAL(focusWindowChanged(QWindow *)),
                    this, SLOT(focusWindowChanged()));
 
@@ -115,7 +100,7 @@ void FileManager::startStopTimer()
                 this, SLOT(focusWindowChanged()));
 
         mTimer->start(1000);
-    } else if ((!opencorActive() || mFiles.isEmpty()) && mTimer->isActive()) {
+    } else if ((!Core::opencorActive() || mFiles.isEmpty()) && mTimer->isActive()) {
         mTimer->stop();
     }
 }
@@ -686,7 +671,7 @@ void FileManager::checkFiles()
     //       means that we can't enable/disable our timer in those acses, hence
     //       our checking that OpenCOR is really active indeed...
 
-    if (!opencorActive())
+    if (!Core::opencorActive())
         return;
 
     // Check our various files, as well as their locked status, but only if they

--- a/src/plugins/miscellaneous/Core/src/filemanager.h
+++ b/src/plugins/miscellaneous/Core/src/filemanager.h
@@ -153,7 +153,6 @@ private:
     QMap<QString, bool> mFilesReadable;
     QMap<QString, bool> mFilesWritable;
 
-    bool opencorActive() const;
     void startStopTimer();
 
     bool newFile(QString &pFileName, const QString &pContents = QString());


### PR DESCRIPTION
 It is also being used by the workspaces' widget.