### PR TITLE
SimulationExperiment view: ensure that the plugin is 'clean'

### DIFF
--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewcontentswidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewcontentswidget.cpp
@@ -38,6 +38,7 @@ namespace SimulationExperimentView {
 //==============================================================================
 
 SimulationExperimentViewContentsWidget::SimulationExperimentViewContentsWidget(SimulationExperimentViewPlugin *pPlugin,
+                                                                               SimulationExperimentViewWidget *pViewWidget,
                                                                                SimulationExperimentViewSimulationWidget *pSimulationWidget,
                                                                                QWidget *pParent) :
     Core::SplitterWidget(pParent)
@@ -49,7 +50,7 @@ SimulationExperimentViewContentsWidget::SimulationExperimentViewContentsWidget(S
 
     // Create our information widget
 
-    mInformationWidget = new SimulationExperimentViewInformationWidget(pPlugin, pSimulationWidget, this);
+    mInformationWidget = new SimulationExperimentViewInformationWidget(pPlugin, pViewWidget, pSimulationWidget, this);
 
     mInformationWidget->setObjectName("Information");
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewcontentswidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewcontentswidget.cpp
@@ -37,8 +37,7 @@ namespace SimulationExperimentView {
 
 //==============================================================================
 
-SimulationExperimentViewContentsWidget::SimulationExperimentViewContentsWidget(SimulationExperimentViewPlugin *pPlugin,
-                                                                               SimulationExperimentViewWidget *pViewWidget,
+SimulationExperimentViewContentsWidget::SimulationExperimentViewContentsWidget(SimulationExperimentViewWidget *pViewWidget,
                                                                                SimulationExperimentViewSimulationWidget *pSimulationWidget,
                                                                                QWidget *pParent) :
     Core::SplitterWidget(pParent)
@@ -50,7 +49,7 @@ SimulationExperimentViewContentsWidget::SimulationExperimentViewContentsWidget(S
 
     // Create our information widget
 
-    mInformationWidget = new SimulationExperimentViewInformationWidget(pPlugin, pViewWidget, pSimulationWidget, this);
+    mInformationWidget = new SimulationExperimentViewInformationWidget(pViewWidget, pSimulationWidget, this);
 
     mInformationWidget->setObjectName("Information");
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewcontentswidget.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewcontentswidget.h
@@ -45,7 +45,6 @@ namespace SimulationExperimentView {
 //==============================================================================
 
 class SimulationExperimentViewInformationWidget;
-class SimulationExperimentViewPlugin;
 class SimulationExperimentViewSimulationWidget;
 class SimulationExperimentViewWidget;
 
@@ -56,8 +55,7 @@ class SimulationExperimentViewContentsWidget : public Core::SplitterWidget
     Q_OBJECT
 
 public:
-    explicit SimulationExperimentViewContentsWidget(SimulationExperimentViewPlugin *pPlugin,
-                                                    SimulationExperimentViewWidget *pViewWidget,
+    explicit SimulationExperimentViewContentsWidget(SimulationExperimentViewWidget *pViewWidget,
                                                     SimulationExperimentViewSimulationWidget *pSimulationWidget,
                                                     QWidget *pParent);
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewcontentswidget.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewcontentswidget.h
@@ -47,6 +47,7 @@ namespace SimulationExperimentView {
 class SimulationExperimentViewInformationWidget;
 class SimulationExperimentViewPlugin;
 class SimulationExperimentViewSimulationWidget;
+class SimulationExperimentViewWidget;
 
 //==============================================================================
 
@@ -56,6 +57,7 @@ class SimulationExperimentViewContentsWidget : public Core::SplitterWidget
 
 public:
     explicit SimulationExperimentViewContentsWidget(SimulationExperimentViewPlugin *pPlugin,
+                                                    SimulationExperimentViewWidget *pViewWidget,
                                                     SimulationExperimentViewSimulationWidget *pSimulationWidget,
                                                     QWidget *pParent);
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationgraphswidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationgraphswidget.cpp
@@ -46,12 +46,12 @@ namespace SimulationExperimentView {
 
 //==============================================================================
 
-SimulationExperimentViewInformationGraphsWidget::SimulationExperimentViewInformationGraphsWidget(SimulationExperimentViewPlugin *pPlugin,
+SimulationExperimentViewInformationGraphsWidget::SimulationExperimentViewInformationGraphsWidget(SimulationExperimentViewWidget *pViewWidget,
                                                                                                  SimulationExperimentViewSimulationWidget *pSimulationWidget,
                                                                                                  QWidget *pParent) :
     QStackedWidget(pParent),
     Core::CommonWidget(this),
-    mPlugin(pPlugin),
+    mViewWidget(pViewWidget),
     mSimulationWidget(pSimulationWidget),
     mGraphPanels(QMap<Core::PropertyEditorWidget *, GraphPanelWidget::GraphPanelWidget *>()),
     mPropertyEditors(QMap<GraphPanelWidget::GraphPanelWidget *, Core::PropertyEditorWidget *>()),
@@ -756,7 +756,7 @@ void SimulationExperimentViewInformationGraphsWidget::updateGraphInfo(Core::Prop
     //       assignment...
 
     bool graphOk = true;
-    CellMLSupport::CellmlFileRuntime *runtime = mPlugin->viewWidget()->runtime(fileName);
+    CellMLSupport::CellmlFileRuntime *runtime = mViewWidget->runtime(fileName);
     CellMLSupport::CellmlFileRuntimeParameter *oldParameterX = static_cast<CellMLSupport::CellmlFileRuntimeParameter *>(graph->parameterX());
     CellMLSupport::CellmlFileRuntimeParameter *oldParameterY = static_cast<CellMLSupport::CellmlFileRuntimeParameter *>(graph->parameterY());
 
@@ -855,7 +855,7 @@ void SimulationExperimentViewInformationGraphsWidget::updateGraphsInfo(Core::Pro
 
     QStringList modelListValues = QStringList();
 
-    foreach (const QString &fileName, mPlugin->viewWidget()->fileNames()) {
+    foreach (const QString &fileName, mViewWidget->fileNames()) {
         Core::File *file = Core::FileManager::instance()->file(fileName);
         QString fileNameOrUrl = file->isLocal()?fileName:file->url();
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationgraphswidget.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationgraphswidget.h
@@ -57,9 +57,9 @@ namespace SimulationExperimentView {
 
 //==============================================================================
 
-class SimulationExperimentViewPlugin;
 class SimulationExperimentViewSimulation;
 class SimulationExperimentViewSimulationWidget;
+class SimulationExperimentViewWidget;
 
 //==============================================================================
 
@@ -69,7 +69,7 @@ class SimulationExperimentViewInformationGraphsWidget : public QStackedWidget,
     Q_OBJECT
 
 public:
-    explicit SimulationExperimentViewInformationGraphsWidget(SimulationExperimentViewPlugin *pPlugin,
+    explicit SimulationExperimentViewInformationGraphsWidget(SimulationExperimentViewWidget *pViewWidget,
                                                              SimulationExperimentViewSimulationWidget *pSimulationWidget,
                                                              QWidget *pParent);
 
@@ -91,7 +91,7 @@ public:
     void setColumnWidth(const int &pIndex, const int &pColumnWidth);
 
 private:
-    SimulationExperimentViewPlugin *mPlugin;
+    SimulationExperimentViewWidget *mViewWidget;
     SimulationExperimentViewSimulationWidget *mSimulationWidget;
 
     QMap<Core::PropertyEditorWidget *, GraphPanelWidget::GraphPanelWidget *> mGraphPanels;

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationsolverswidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationsolverswidget.cpp
@@ -24,8 +24,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "cellmlfileruntime.h"
 #include "corecliutils.h"
 #include "simulationexperimentviewinformationsolverswidget.h"
-#include "simulationexperimentviewplugin.h"
 #include "simulationexperimentviewsimulation.h"
+#include "simulationexperimentviewwidget.h"
 
 //==============================================================================
 
@@ -83,7 +83,7 @@ QMap<QString, Core::Properties> SimulationExperimentViewInformationSolversWidget
 
 //==============================================================================
 
-SimulationExperimentViewInformationSolversWidget::SimulationExperimentViewInformationSolversWidget(SimulationExperimentViewPlugin *pPlugin,
+SimulationExperimentViewInformationSolversWidget::SimulationExperimentViewInformationSolversWidget(SimulationExperimentViewWidget *pViewWidget,
                                                                                                    QWidget *pParent) :
     PropertyEditorWidget(true, pParent),
     mDescriptions(QMap<Core::Property *, Descriptions>())
@@ -94,9 +94,9 @@ SimulationExperimentViewInformationSolversWidget::SimulationExperimentViewInform
 
     // Add properties for our different solvers
 
-    mOdeSolverData = addSolverProperties(pPlugin->solverInterfaces(), Solver::Ode);
-    mDaeSolverData = addSolverProperties(pPlugin->solverInterfaces(), Solver::Dae);
-    mNlaSolverData = addSolverProperties(pPlugin->solverInterfaces(), Solver::Nla);
+    mOdeSolverData = addSolverProperties(pViewWidget->solverInterfaces(), Solver::Ode);
+    mDaeSolverData = addSolverProperties(pViewWidget->solverInterfaces(), Solver::Dae);
+    mNlaSolverData = addSolverProperties(pViewWidget->solverInterfaces(), Solver::Nla);
 
     // Show/hide the relevant properties
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationsolverswidget.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationsolverswidget.h
@@ -38,8 +38,8 @@ namespace SimulationExperimentView {
 
 //==============================================================================
 
-class SimulationExperimentViewPlugin;
 class SimulationExperimentViewSimulation;
+class SimulationExperimentViewWidget;
 
 //==============================================================================
 
@@ -74,7 +74,7 @@ class SimulationExperimentViewInformationSolversWidget : public Core::PropertyEd
     Q_OBJECT
 
 public:
-    explicit SimulationExperimentViewInformationSolversWidget(SimulationExperimentViewPlugin *pPlugin,
+    explicit SimulationExperimentViewInformationSolversWidget(SimulationExperimentViewWidget *pViewWidget,
                                                               QWidget *pParent);
     ~SimulationExperimentViewInformationSolversWidget();
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationwidget.cpp
@@ -40,8 +40,7 @@ namespace SimulationExperimentView {
 
 //==============================================================================
 
-SimulationExperimentViewInformationWidget::SimulationExperimentViewInformationWidget(SimulationExperimentViewPlugin *pPlugin,
-                                                                                     SimulationExperimentViewWidget *pViewWidget,
+SimulationExperimentViewInformationWidget::SimulationExperimentViewInformationWidget(SimulationExperimentViewWidget *pViewWidget,
                                                                                      SimulationExperimentViewSimulationWidget *pSimulationWidget,
                                                                                      QWidget *pParent) :
     QScrollArea(pParent),
@@ -74,7 +73,7 @@ SimulationExperimentViewInformationWidget::SimulationExperimentViewInformationWi
 
     // Create our solvers widget
 
-    mSolversWidget = new SimulationExperimentViewInformationSolversWidget(pPlugin, mCollapsibleWidget);
+    mSolversWidget = new SimulationExperimentViewInformationSolversWidget(pViewWidget, mCollapsibleWidget);
 
     mSolversWidget->setObjectName("Solvers");
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationwidget.cpp
@@ -41,6 +41,7 @@ namespace SimulationExperimentView {
 //==============================================================================
 
 SimulationExperimentViewInformationWidget::SimulationExperimentViewInformationWidget(SimulationExperimentViewPlugin *pPlugin,
+                                                                                     SimulationExperimentViewWidget *pViewWidget,
                                                                                      SimulationExperimentViewSimulationWidget *pSimulationWidget,
                                                                                      QWidget *pParent) :
     QScrollArea(pParent),
@@ -79,7 +80,7 @@ SimulationExperimentViewInformationWidget::SimulationExperimentViewInformationWi
 
     // Create our graphs widget
 
-    mGraphsWidget = new SimulationExperimentViewInformationGraphsWidget(pPlugin, pSimulationWidget, mCollapsibleWidget);
+    mGraphsWidget = new SimulationExperimentViewInformationGraphsWidget(pViewWidget, pSimulationWidget, mCollapsibleWidget);
 
     mGraphsWidget->setObjectName("Graphs");
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationwidget.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationwidget.h
@@ -53,6 +53,7 @@ class SimulationExperimentViewInformationSimulationWidget;
 class SimulationExperimentViewInformationSolversWidget;
 class SimulationExperimentViewPlugin;
 class SimulationExperimentViewSimulationWidget;
+class SimulationExperimentViewWidget;
 
 //==============================================================================
 
@@ -63,6 +64,7 @@ class SimulationExperimentViewInformationWidget : public QScrollArea,
 
 public:
     explicit SimulationExperimentViewInformationWidget(SimulationExperimentViewPlugin *pPlugin,
+                                                       SimulationExperimentViewWidget *pViewWidget,
                                                        SimulationExperimentViewSimulationWidget *pSimulationWidget,
                                                        QWidget *pParent);
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationwidget.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationwidget.h
@@ -51,7 +51,6 @@ class SimulationExperimentViewInformationGraphsWidget;
 class SimulationExperimentViewInformationParametersWidget;
 class SimulationExperimentViewInformationSimulationWidget;
 class SimulationExperimentViewInformationSolversWidget;
-class SimulationExperimentViewPlugin;
 class SimulationExperimentViewSimulationWidget;
 class SimulationExperimentViewWidget;
 
@@ -63,8 +62,7 @@ class SimulationExperimentViewInformationWidget : public QScrollArea,
     Q_OBJECT
 
 public:
-    explicit SimulationExperimentViewInformationWidget(SimulationExperimentViewPlugin *pPlugin,
-                                                       SimulationExperimentViewWidget *pViewWidget,
+    explicit SimulationExperimentViewInformationWidget(SimulationExperimentViewWidget *pViewWidget,
                                                        SimulationExperimentViewSimulationWidget *pSimulationWidget,
                                                        QWidget *pParent);
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.cpp
@@ -184,6 +184,7 @@ void SimulationExperimentViewPlugin::initializePlugin()
     // Create our Simulation Experiment view widget
 
     mViewWidget = new SimulationExperimentViewWidget(this, mSolverInterfaces,
+                                                     mDataStoreInterfaces,
                                                      Core::mainWindow());
 
     mViewWidget->setObjectName("SimulationExperimentViewWidget");
@@ -371,15 +372,6 @@ QIcon SimulationExperimentViewPlugin::fileTabIcon(const QString &pFileName) cons
 
 //==============================================================================
 // Plugin specific
-//==============================================================================
-
-DataStoreInterfaces SimulationExperimentViewPlugin::dataStoreInterfaces() const
-{
-    // Return our data store interfaces
-
-    return mDataStoreInterfaces;
-}
-
 //==============================================================================
 
 Plugins SimulationExperimentViewPlugin::cellmlEditingViewPlugins() const

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.cpp
@@ -187,6 +187,8 @@ void SimulationExperimentViewPlugin::initializePlugin()
                                                      mDataStoreInterfaces,
                                                      mCellmlEditingViewPlugins,
                                                      mCellmlSimulationViewPlugins,
+                                                     mSedmlFileTypeInterface,
+                                                     mCombineFileTypeInterface,
                                                      Core::mainWindow());
 
     mViewWidget->setObjectName("SimulationExperimentViewWidget");
@@ -370,26 +372,6 @@ QIcon SimulationExperimentViewPlugin::fileTabIcon(const QString &pFileName) cons
     // Return the requested file tab icon
 
     return mViewWidget->fileTabIcon(pFileName);
-}
-
-//==============================================================================
-// Plugin specific
-//==============================================================================
-
-FileTypeInterface * SimulationExperimentViewPlugin::sedmlFileTypeInterface() const
-{
-    // Return our SED-ML file type interface
-
-    return mSedmlFileTypeInterface;
-}
-
-//==============================================================================
-
-FileTypeInterface * SimulationExperimentViewPlugin::combineFileTypeInterface() const
-{
-    // Return our COMBINE file type interface
-
-    return mCombineFileTypeInterface;
 }
 
 //==============================================================================

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.cpp
@@ -183,7 +183,8 @@ void SimulationExperimentViewPlugin::initializePlugin()
 {
     // Create our Simulation Experiment view widget
 
-    mViewWidget = new SimulationExperimentViewWidget(this, Core::mainWindow());
+    mViewWidget = new SimulationExperimentViewWidget(this, mSolverInterfaces,
+                                                     Core::mainWindow());
 
     mViewWidget->setObjectName("SimulationExperimentViewWidget");
 
@@ -370,15 +371,6 @@ QIcon SimulationExperimentViewPlugin::fileTabIcon(const QString &pFileName) cons
 
 //==============================================================================
 // Plugin specific
-//==============================================================================
-
-SolverInterfaces SimulationExperimentViewPlugin::solverInterfaces() const
-{
-    // Return our solver interfaces
-
-    return mSolverInterfaces;
-}
-
 //==============================================================================
 
 DataStoreInterfaces SimulationExperimentViewPlugin::dataStoreInterfaces() const

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.cpp
@@ -185,6 +185,8 @@ void SimulationExperimentViewPlugin::initializePlugin()
 
     mViewWidget = new SimulationExperimentViewWidget(this, mSolverInterfaces,
                                                      mDataStoreInterfaces,
+                                                     mCellmlEditingViewPlugins,
+                                                     mCellmlSimulationViewPlugins,
                                                      Core::mainWindow());
 
     mViewWidget->setObjectName("SimulationExperimentViewWidget");
@@ -372,24 +374,6 @@ QIcon SimulationExperimentViewPlugin::fileTabIcon(const QString &pFileName) cons
 
 //==============================================================================
 // Plugin specific
-//==============================================================================
-
-Plugins SimulationExperimentViewPlugin::cellmlEditingViewPlugins() const
-{
-    // Return our CellML editing view plugins
-
-    return mCellmlEditingViewPlugins;
-}
-
-//==============================================================================
-
-Plugins SimulationExperimentViewPlugin::cellmlSimulationViewPlugins() const
-{
-    // Return our CellML simulation view plugins
-
-    return mCellmlSimulationViewPlugins;
-}
-
 //==============================================================================
 
 FileTypeInterface * SimulationExperimentViewPlugin::sedmlFileTypeInterface() const

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.cpp
@@ -372,15 +372,6 @@ QIcon SimulationExperimentViewPlugin::fileTabIcon(const QString &pFileName) cons
 // Plugin specific
 //==============================================================================
 
-SimulationExperimentViewWidget * SimulationExperimentViewPlugin::viewWidget() const
-{
-    // Return our view widget
-
-    return mViewWidget;
-}
-
-//==============================================================================
-
 SolverInterfaces SimulationExperimentViewPlugin::solverInterfaces() const
 {
     // Return our solver interfaces

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.h
@@ -72,9 +72,6 @@ public:
 #include "plugininterface.inl"
 #include "viewinterface.inl"
 
-    Plugins cellmlEditingViewPlugins() const;
-    Plugins cellmlSimulationViewPlugins() const;
-
     FileTypeInterface * sedmlFileTypeInterface() const;
     FileTypeInterface * combineFileTypeInterface() const;
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.h
@@ -72,7 +72,6 @@ public:
 #include "plugininterface.inl"
 #include "viewinterface.inl"
 
-    SolverInterfaces solverInterfaces() const;
     DataStoreInterfaces dataStoreInterfaces() const;
 
     Plugins cellmlEditingViewPlugins() const;
@@ -86,6 +85,7 @@ private:
 
     SolverInterfaces mSolverInterfaces;
     DataStoreInterfaces mDataStoreInterfaces;
+
     Plugins mCellmlEditingViewPlugins;
     Plugins mCellmlSimulationViewPlugins;
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.h
@@ -72,8 +72,6 @@ public:
 #include "plugininterface.inl"
 #include "viewinterface.inl"
 
-    SimulationExperimentViewWidget * viewWidget() const;
-
     SolverInterfaces solverInterfaces() const;
     DataStoreInterfaces dataStoreInterfaces() const;
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.h
@@ -72,9 +72,6 @@ public:
 #include "plugininterface.inl"
 #include "viewinterface.inl"
 
-    FileTypeInterface * sedmlFileTypeInterface() const;
-    FileTypeInterface * combineFileTypeInterface() const;
-
 private:
     SimulationExperimentViewWidget *mViewWidget;
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.h
@@ -72,8 +72,6 @@ public:
 #include "plugininterface.inl"
 #include "viewinterface.inl"
 
-    DataStoreInterfaces dataStoreInterfaces() const;
-
     Plugins cellmlEditingViewPlugins() const;
     Plugins cellmlSimulationViewPlugins() const;
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
@@ -219,7 +219,7 @@ SimulationExperimentViewSimulationWidget::SimulationExperimentViewSimulationWidg
     cellmlOpenToolButton->setMenu(cellmlOpenDropDownMenu);
     cellmlOpenToolButton->setPopupMode(QToolButton::MenuButtonPopup);
 
-    foreach (Plugin *cellmlEditingViewPlugin, pPlugin->cellmlEditingViewPlugins()) {
+    foreach (Plugin *cellmlEditingViewPlugin, pViewWidget->cellmlEditingViewPlugins()) {
         QAction *action = Core::newAction(Core::mainWindow());
 
         cellmlOpenDropDownMenu->addAction(action);
@@ -232,7 +232,7 @@ SimulationExperimentViewSimulationWidget::SimulationExperimentViewSimulationWidg
 
     cellmlOpenDropDownMenu->addSeparator();
 
-    foreach (Plugin *cellmlSimulationViewPlugin, pPlugin->cellmlSimulationViewPlugins()) {
+    foreach (Plugin *cellmlSimulationViewPlugin, pViewWidget->cellmlSimulationViewPlugins()) {
         QAction *action = Core::newAction(Core::mainWindow());
 
         cellmlOpenDropDownMenu->addAction(action);

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
@@ -323,7 +323,7 @@ SimulationExperimentViewSimulationWidget::SimulationExperimentViewSimulationWidg
 
     // Create our contents widget
 
-    mContentsWidget = new SimulationExperimentViewContentsWidget(pPlugin, pViewWidget, this, this);
+    mContentsWidget = new SimulationExperimentViewContentsWidget(pViewWidget, this, this);
 
     mContentsWidget->setObjectName("Contents");
 
@@ -454,7 +454,7 @@ SimulationExperimentViewSimulationWidget::SimulationExperimentViewSimulationWidg
                         mFileType, mSedmlFileIssues, mCombineArchiveIssues);
 
     mSimulation = new SimulationExperimentViewSimulation(mCellmlFile?mCellmlFile->runtime(true):0,
-                                                         pPlugin->solverInterfaces());
+                                                         pViewWidget->solverInterfaces());
 
     connect(mSimulation, SIGNAL(running(const bool &)),
             this, SLOT(simulationRunning(const bool &)));
@@ -2157,7 +2157,7 @@ bool SimulationExperimentViewSimulationWidget::doFurtherInitialize()
     Core::Properties solverProperties = Core::Properties();
     QString kisaoId = QString::fromStdString(algorithm->getKisaoID());
 
-    foreach (SolverInterface *solverInterface, mPlugin->solverInterfaces()) {
+    foreach (SolverInterface *solverInterface, mViewWidget->solverInterfaces()) {
         if (!solverInterface->id(kisaoId).compare(solverInterface->solverName())) {
             usedSolverInterface = solverInterface;
             solverProperties = solverData->solversProperties().value(solverInterface->solverName());
@@ -2291,7 +2291,7 @@ bool SimulationExperimentViewSimulationWidget::doFurtherInitialize()
             mustHaveNlaSolver = true;
             nlaSolverName = QString::fromStdString(node.getAttrValue(node.getAttrIndex(SEDMLSupport::NlaSolverName.toStdString())));
 
-            foreach (SolverInterface *solverInterface, mPlugin->solverInterfaces()) {
+            foreach (SolverInterface *solverInterface, mViewWidget->solverInterfaces()) {
                 if (!nlaSolverName.compare(solverInterface->solverName())) {
                     informationWidget->solversWidget()->nlaSolverData()->solversListProperty()->setValue(nlaSolverName);
 
@@ -3328,7 +3328,7 @@ bool SimulationExperimentViewSimulationWidget::sedmlAlgorithmSupported(const lib
     SolverInterface *usedSolverInterface = 0;
     QString kisaoId = QString::fromStdString(pSedmlAlgorithm->getKisaoID());
 
-    foreach (SolverInterface *solverInterface, mPlugin->solverInterfaces()) {
+    foreach (SolverInterface *solverInterface, mViewWidget->solverInterfaces()) {
         if (!solverInterface->id(kisaoId).compare(solverInterface->solverName())) {
             usedSolverInterface = solverInterface;
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
@@ -261,7 +261,7 @@ SimulationExperimentViewSimulationWidget::SimulationExperimentViewSimulationWidg
     simulationDataExportToolButton->setMenu(mSimulationDataExportDropDownMenu);
     simulationDataExportToolButton->setPopupMode(QToolButton::InstantPopup);
 
-    foreach (DataStoreInterface *dataStoreInterface, pPlugin->dataStoreInterfaces()) {
+    foreach (DataStoreInterface *dataStoreInterface, pViewWidget->dataStoreInterfaces()) {
         QString dataStoreName = dataStoreInterface->dataStoreName();
         QAction *action = mSimulationDataExportDropDownMenu->addAction(dataStoreName+"...");
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
@@ -90,10 +90,12 @@ namespace SimulationExperimentView {
 //==============================================================================
 
 SimulationExperimentViewSimulationWidget::SimulationExperimentViewSimulationWidget(SimulationExperimentViewPlugin *pPlugin,
+                                                                                   SimulationExperimentViewWidget *pViewWidget,
                                                                                    const QString &pFileName,
                                                                                    QWidget *pParent) :
     Widget(pParent),
     mPlugin(pPlugin),
+    mViewWidget(pViewWidget),
     mFileName(pFileName),
     mDataStoreInterfaces(QMap<QAction *, DataStoreInterface *>()),
     mCellmlBasedViewPlugins(QMap<QAction *, Plugin *>()),
@@ -321,7 +323,7 @@ SimulationExperimentViewSimulationWidget::SimulationExperimentViewSimulationWidg
 
     // Create our contents widget
 
-    mContentsWidget = new SimulationExperimentViewContentsWidget(pPlugin, this, this);
+    mContentsWidget = new SimulationExperimentViewContentsWidget(pPlugin, pViewWidget, this, this);
 
     mContentsWidget->setObjectName("Contents");
 
@@ -1325,7 +1327,7 @@ void SimulationExperimentViewSimulationWidget::runPauseResumeSimulation()
 
                 runSimulation = mSimulation->results()->reset();
 
-                mPlugin->viewWidget()->checkSimulationResults(mFileName, true);
+                mViewWidget->checkSimulationResults(mFileName, true);
                 // Note: this will, among other things, clear our plots...
 
                 // Effectively run our simulation in case we were able to
@@ -1376,7 +1378,7 @@ void SimulationExperimentViewSimulationWidget::clearSimulationData()
 
     updateSimulationMode();
 
-    mPlugin->viewWidget()->checkSimulationResults(mFileName, true);
+    mViewWidget->checkSimulationResults(mFileName, true);
 }
 
 //==============================================================================
@@ -2482,7 +2484,7 @@ void SimulationExperimentViewSimulationWidget::simulationRunning(const bool &pIs
 
     updateSimulationMode();
 
-    mPlugin->viewWidget()->checkSimulationResults(mFileName);
+    mViewWidget->checkSimulationResults(mFileName);
 }
 
 //==============================================================================
@@ -2496,7 +2498,7 @@ void SimulationExperimentViewSimulationWidget::simulationPaused()
 
     mContentsWidget->informationWidget()->parametersWidget()->updateParameters(mSimulation->currentPoint());
 
-    mPlugin->viewWidget()->checkSimulationResults(mFileName);
+    mViewWidget->checkSimulationResults(mFileName);
 }
 
 //==============================================================================
@@ -2561,7 +2563,7 @@ void SimulationExperimentViewSimulationWidget::resetFileTabIcon()
 
     static const QIcon NoIcon = QIcon();
 
-    emit mPlugin->viewWidget()->updateFileTabIcon(mPlugin->viewName(), mFileName, NoIcon);
+    emit mViewWidget->updateFileTabIcon(mPlugin->viewName(), mFileName, NoIcon);
 }
 
 //==============================================================================
@@ -2789,7 +2791,7 @@ void SimulationExperimentViewSimulationWidget::graphsUpdated(OpenCOR::GraphPanel
         //       indeed refer to a file that has not yet been activated and
         //       therefore doesn't yet have a simulation associated with it...
 
-        SimulationExperimentViewSimulation *simulation = mPlugin->viewWidget()->simulation(graph->fileName());
+        SimulationExperimentViewSimulation *simulation = mViewWidget->simulation(graph->fileName());
 
         updateGraphData(graph, simulation?simulation->results()->size():0);
 
@@ -2873,7 +2875,7 @@ bool SimulationExperimentViewSimulationWidget::updatePlot(GraphPanelWidget::Grap
 
     foreach (GraphPanelWidget::GraphPanelPlotGraph *graph, pPlot->graphs()) {
         if (graph->isValid() && graph->isSelected()) {
-            SimulationExperimentViewSimulation *simulation = mPlugin->viewWidget()->simulation(graph->fileName());
+            SimulationExperimentViewSimulation *simulation = mViewWidget->simulation(graph->fileName());
             double startingPoint = simulation->data()->startingPoint();
             double endingPoint = simulation->data()->endingPoint();
 
@@ -2987,7 +2989,7 @@ void SimulationExperimentViewSimulationWidget::updateGraphData(GraphPanelWidget:
     // Update our graph's data
 
     if (pGraph->isValid()) {
-        SimulationExperimentViewSimulation *simulation = mPlugin->viewWidget()->simulation(pGraph->fileName());
+        SimulationExperimentViewSimulation *simulation = mViewWidget->simulation(pGraph->fileName());
 
         pGraph->setRawSamples(dataPoints(simulation, static_cast<CellMLSupport::CellmlFileRuntimeParameter *>(pGraph->parameterX())),
                               dataPoints(simulation, static_cast<CellMLSupport::CellmlFileRuntimeParameter *>(pGraph->parameterY())),
@@ -3028,7 +3030,7 @@ void SimulationExperimentViewSimulationWidget::updateGui(const bool &pCheckVisib
 
     // Make sure that our progress bar is up to date
 
-    mProgressBarWidget->setValue(mPlugin->viewWidget()->simulationResultsSize(mFileName)/mSimulation->size());
+    mProgressBarWidget->setValue(mViewWidget->simulationResultsSize(mFileName)/mSimulation->size());
 }
 
 //==============================================================================
@@ -3188,7 +3190,7 @@ void SimulationExperimentViewSimulationWidget::updateSimulationResults(Simulatio
     // Update our progress bar or our tab icon, if needed
 
     if (simulation == mSimulation) {
-        double simulationProgress = mPlugin->viewWidget()->simulationResultsSize(mFileName)/simulation->size();
+        double simulationProgress = mViewWidget->simulationResultsSize(mFileName)/simulation->size();
 
         if (pClearGraphs || visible) {
             mProgressBarWidget->setValue(simulationProgress);
@@ -3209,7 +3211,7 @@ void SimulationExperimentViewSimulationWidget::updateSimulationResults(Simulatio
                 // Let people know about the file tab icon to be used for the
                 // model
 
-                emit mPlugin->viewWidget()->updateFileTabIcon(mPlugin->viewName(), mFileName, fileTabIcon());
+                emit mViewWidget->updateFileTabIcon(mPlugin->viewName(), mFileName, fileTabIcon());
             }
         }
     }

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
@@ -1734,7 +1734,7 @@ void SimulationExperimentViewSimulationWidget::sedmlExportSedmlFile()
     QString cellmlFileName = remoteFile?fileManagerInstance->url(mFileName):mFileName;
     QString cellmlFileCompleteSuffix = QFileInfo(cellmlFileName).completeSuffix();
     QString sedmlFileName = cellmlFileName;
-    QStringList sedmlFilters = Core::filters(FileTypeInterfaces() << mPlugin->sedmlFileTypeInterface());
+    QStringList sedmlFilters = Core::filters(FileTypeInterfaces() << mViewWidget->sedmlFileTypeInterface());
     QString firstSedmlFilter = sedmlFilters.first();
 
     if (!cellmlFileCompleteSuffix.isEmpty()) {
@@ -1788,7 +1788,7 @@ void SimulationExperimentViewSimulationWidget::sedmlExportCombineArchive()
     QString cellmlFileName = remoteFile?fileManagerInstance->url(mFileName):mFileName;
     QString cellmlFileCompleteSuffix = QFileInfo(cellmlFileName).completeSuffix();
     QString combineArchiveName = cellmlFileName;
-    QStringList combineFilters = Core::filters(FileTypeInterfaces() << mPlugin->combineFileTypeInterface());
+    QStringList combineFilters = Core::filters(FileTypeInterfaces() << mViewWidget->combineFileTypeInterface());
     QString firstCombineFilter = combineFilters.first();
 
     if (!cellmlFileCompleteSuffix.isEmpty()) {

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.h
@@ -114,6 +114,7 @@ public:
     };
 
     explicit SimulationExperimentViewSimulationWidget(SimulationExperimentViewPlugin *pPlugin,
+                                                      SimulationExperimentViewWidget *pViewWidget,
                                                       const QString &pFileName,
                                                       QWidget *pParent);
     ~SimulationExperimentViewSimulationWidget();
@@ -161,6 +162,8 @@ private:
     };
 
     SimulationExperimentViewPlugin *mPlugin;
+
+    SimulationExperimentViewWidget *mViewWidget;
 
     QString mFileName;
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.cpp
@@ -193,7 +193,7 @@ void SimulationExperimentViewWidget::initialize(const QString &pFileName)
     if (!mSimulationWidget) {
         // No simulation widget exists for the given file, so create one
 
-        mSimulationWidget = new SimulationExperimentViewSimulationWidget(mPlugin, pFileName, this);
+        mSimulationWidget = new SimulationExperimentViewSimulationWidget(mPlugin, this, pFileName, this);
 
         // Keep track of our editing widget
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.cpp
@@ -74,6 +74,8 @@ SimulationExperimentViewWidget::SimulationExperimentViewWidget(SimulationExperim
                                                                const DataStoreInterfaces &pDataStoreInterfaces,
                                                                const Plugins &pCellmlEditingViewPlugins,
                                                                const Plugins &pCellmlSimulationViewPlugins,
+                                                               FileTypeInterface *pSedmlFileTypeInterface,
+                                                               FileTypeInterface *pCombineFileTypeInterface,
                                                                QWidget *pParent) :
     ViewWidget(pParent),
     mPlugin(pPlugin),
@@ -81,6 +83,8 @@ SimulationExperimentViewWidget::SimulationExperimentViewWidget(SimulationExperim
     mDataStoreInterfaces(pDataStoreInterfaces),
     mCellmlEditingViewPlugins(pCellmlEditingViewPlugins),
     mCellmlSimulationViewPlugins(pCellmlSimulationViewPlugins),
+    mSedmlFileTypeInterface(pSedmlFileTypeInterface),
+    mCombineFileTypeInterface(pCombineFileTypeInterface),
     mSimulationWidgetSizes(QIntList()),
     mContentsWidgetSizes(QIntList()),
     mCollapsibleWidgetCollapsed(QBoolList()),
@@ -467,6 +471,24 @@ Plugins SimulationExperimentViewWidget::cellmlSimulationViewPlugins() const
     // Return our CellML simulation view plugins
 
     return mCellmlSimulationViewPlugins;
+}
+
+//==============================================================================
+
+FileTypeInterface * SimulationExperimentViewWidget::sedmlFileTypeInterface() const
+{
+    // Return our SED-ML file type interface
+
+    return mSedmlFileTypeInterface;
+}
+
+//==============================================================================
+
+FileTypeInterface * SimulationExperimentViewWidget::combineFileTypeInterface() const
+{
+    // Return our COMBINE file type interface
+
+    return mCombineFileTypeInterface;
 }
 
 //==============================================================================

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.cpp
@@ -70,9 +70,11 @@ namespace SimulationExperimentView {
 //==============================================================================
 
 SimulationExperimentViewWidget::SimulationExperimentViewWidget(SimulationExperimentViewPlugin *pPlugin,
+                                                               const SolverInterfaces &pSolverInterfaces,
                                                                QWidget *pParent) :
     ViewWidget(pParent),
     mPlugin(pPlugin),
+    mSolverInterfaces(pSolverInterfaces),
     mSimulationWidgetSizes(QIntList()),
     mContentsWidgetSizes(QIntList()),
     mCollapsibleWidgetCollapsed(QBoolList()),
@@ -423,6 +425,15 @@ QStringList SimulationExperimentViewWidget::fileNames() const
     // Return our file names
 
     return mFileNames;
+}
+
+//==============================================================================
+
+SolverInterfaces SimulationExperimentViewWidget::solverInterfaces() const
+{
+    // Return our solver interfaces
+
+    return mSolverInterfaces;
 }
 
 //==============================================================================

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.cpp
@@ -71,10 +71,12 @@ namespace SimulationExperimentView {
 
 SimulationExperimentViewWidget::SimulationExperimentViewWidget(SimulationExperimentViewPlugin *pPlugin,
                                                                const SolverInterfaces &pSolverInterfaces,
+                                                               const DataStoreInterfaces &pDataStoreInterfaces,
                                                                QWidget *pParent) :
     ViewWidget(pParent),
     mPlugin(pPlugin),
     mSolverInterfaces(pSolverInterfaces),
+    mDataStoreInterfaces(pDataStoreInterfaces),
     mSimulationWidgetSizes(QIntList()),
     mContentsWidgetSizes(QIntList()),
     mCollapsibleWidgetCollapsed(QBoolList()),
@@ -434,6 +436,15 @@ SolverInterfaces SimulationExperimentViewWidget::solverInterfaces() const
     // Return our solver interfaces
 
     return mSolverInterfaces;
+}
+
+//==============================================================================
+
+DataStoreInterfaces SimulationExperimentViewWidget::dataStoreInterfaces() const
+{
+    // Return our data store interfaces
+
+    return mDataStoreInterfaces;
 }
 
 //==============================================================================

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.cpp
@@ -72,11 +72,15 @@ namespace SimulationExperimentView {
 SimulationExperimentViewWidget::SimulationExperimentViewWidget(SimulationExperimentViewPlugin *pPlugin,
                                                                const SolverInterfaces &pSolverInterfaces,
                                                                const DataStoreInterfaces &pDataStoreInterfaces,
+                                                               const Plugins &pCellmlEditingViewPlugins,
+                                                               const Plugins &pCellmlSimulationViewPlugins,
                                                                QWidget *pParent) :
     ViewWidget(pParent),
     mPlugin(pPlugin),
     mSolverInterfaces(pSolverInterfaces),
     mDataStoreInterfaces(pDataStoreInterfaces),
+    mCellmlEditingViewPlugins(pCellmlEditingViewPlugins),
+    mCellmlSimulationViewPlugins(pCellmlSimulationViewPlugins),
     mSimulationWidgetSizes(QIntList()),
     mContentsWidgetSizes(QIntList()),
     mCollapsibleWidgetCollapsed(QBoolList()),
@@ -445,6 +449,24 @@ DataStoreInterfaces SimulationExperimentViewWidget::dataStoreInterfaces() const
     // Return our data store interfaces
 
     return mDataStoreInterfaces;
+}
+
+//==============================================================================
+
+Plugins SimulationExperimentViewWidget::cellmlEditingViewPlugins() const
+{
+    // Return our CellML editing view plugins
+
+    return mCellmlEditingViewPlugins;
+}
+
+//==============================================================================
+
+Plugins SimulationExperimentViewWidget::cellmlSimulationViewPlugins() const
+{
+    // Return our CellML simulation view plugins
+
+    return mCellmlSimulationViewPlugins;
 }
 
 //==============================================================================

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.h
@@ -60,6 +60,8 @@ public:
     explicit SimulationExperimentViewWidget(SimulationExperimentViewPlugin *pPlugin,
                                             const SolverInterfaces &pSolverInterfaces,
                                             const DataStoreInterfaces &pDataStoreInterfaces,
+                                            const Plugins &pCellmlEditingViewPlugins,
+                                            const Plugins &pCellmlSimulationViewPlugins,
                                             QWidget *pParent);
 
     virtual void loadSettings(QSettings *pSettings);
@@ -86,6 +88,9 @@ public:
     SolverInterfaces solverInterfaces() const;
     DataStoreInterfaces dataStoreInterfaces() const;
 
+    Plugins cellmlEditingViewPlugins() const;
+    Plugins cellmlSimulationViewPlugins() const;
+
     SimulationExperimentViewSimulationWidget * simulationWidget(const QString &pFileName) const;
     SimulationExperimentViewSimulation * simulation(const QString &pFileName) const;
     CellMLSupport::CellmlFileRuntime * runtime(const QString &pFileName) const;
@@ -102,6 +107,9 @@ private:
 
     SolverInterfaces mSolverInterfaces;
     DataStoreInterfaces mDataStoreInterfaces;
+
+    Plugins mCellmlEditingViewPlugins;
+    Plugins mCellmlSimulationViewPlugins;
 
     QIntList mSimulationWidgetSizes;
     QIntList mContentsWidgetSizes;

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.h
@@ -29,6 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "combinearchive.h"
 #include "corecliutils.h"
 #include "sedmlfile.h"
+#include "solverinterface.h"
 #include "viewwidget.h"
 
 //==============================================================================
@@ -56,6 +57,7 @@ class SimulationExperimentViewWidget : public Core::ViewWidget
 
 public:
     explicit SimulationExperimentViewWidget(SimulationExperimentViewPlugin *pPlugin,
+                                            const SolverInterfaces &pSolverInterfaces,
                                             QWidget *pParent);
 
     virtual void loadSettings(QSettings *pSettings);
@@ -79,6 +81,8 @@ public:
 
     QStringList fileNames() const;
 
+    SolverInterfaces solverInterfaces() const;
+
     SimulationExperimentViewSimulationWidget * simulationWidget(const QString &pFileName) const;
     SimulationExperimentViewSimulation * simulation(const QString &pFileName) const;
     CellMLSupport::CellmlFileRuntime * runtime(const QString &pFileName) const;
@@ -92,6 +96,8 @@ public:
 
 private:
     SimulationExperimentViewPlugin *mPlugin;
+
+    SolverInterfaces mSolverInterfaces;
 
     QIntList mSimulationWidgetSizes;
     QIntList mContentsWidgetSizes;

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.h
@@ -29,6 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "combinearchive.h"
 #include "corecliutils.h"
 #include "datastoreinterface.h"
+#include "filetypeinterface.h"
 #include "sedmlfile.h"
 #include "solverinterface.h"
 #include "viewwidget.h"
@@ -62,6 +63,8 @@ public:
                                             const DataStoreInterfaces &pDataStoreInterfaces,
                                             const Plugins &pCellmlEditingViewPlugins,
                                             const Plugins &pCellmlSimulationViewPlugins,
+                                            FileTypeInterface *pSedmlFileTypeInterface,
+                                            FileTypeInterface *pCombineFileTypeInterface,
                                             QWidget *pParent);
 
     virtual void loadSettings(QSettings *pSettings);
@@ -91,6 +94,9 @@ public:
     Plugins cellmlEditingViewPlugins() const;
     Plugins cellmlSimulationViewPlugins() const;
 
+    FileTypeInterface * sedmlFileTypeInterface() const;
+    FileTypeInterface * combineFileTypeInterface() const;
+
     SimulationExperimentViewSimulationWidget * simulationWidget(const QString &pFileName) const;
     SimulationExperimentViewSimulation * simulation(const QString &pFileName) const;
     CellMLSupport::CellmlFileRuntime * runtime(const QString &pFileName) const;
@@ -110,6 +116,9 @@ private:
 
     Plugins mCellmlEditingViewPlugins;
     Plugins mCellmlSimulationViewPlugins;
+
+    FileTypeInterface *mSedmlFileTypeInterface;
+    FileTypeInterface *mCombineFileTypeInterface;
 
     QIntList mSimulationWidgetSizes;
     QIntList mContentsWidgetSizes;

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewwidget.h
@@ -28,6 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "cellmlfile.h"
 #include "combinearchive.h"
 #include "corecliutils.h"
+#include "datastoreinterface.h"
 #include "sedmlfile.h"
 #include "solverinterface.h"
 #include "viewwidget.h"
@@ -58,6 +59,7 @@ class SimulationExperimentViewWidget : public Core::ViewWidget
 public:
     explicit SimulationExperimentViewWidget(SimulationExperimentViewPlugin *pPlugin,
                                             const SolverInterfaces &pSolverInterfaces,
+                                            const DataStoreInterfaces &pDataStoreInterfaces,
                                             QWidget *pParent);
 
     virtual void loadSettings(QSettings *pSettings);
@@ -82,6 +84,7 @@ public:
     QStringList fileNames() const;
 
     SolverInterfaces solverInterfaces() const;
+    DataStoreInterfaces dataStoreInterfaces() const;
 
     SimulationExperimentViewSimulationWidget * simulationWidget(const QString &pFileName) const;
     SimulationExperimentViewSimulation * simulation(const QString &pFileName) const;
@@ -98,6 +101,7 @@ private:
     SimulationExperimentViewPlugin *mPlugin;
 
     SolverInterfaces mSolverInterfaces;
+    DataStoreInterfaces mDataStoreInterfaces;
 
     QIntList mSimulationWidgetSizes;
     QIntList mContentsWidgetSizes;


### PR DESCRIPTION
 Indeed, the plugin currently has some public methods that are not part of any of our interfaces, which is not right since it breaks our interface approach to plugins.