### PR TITLE
SimulationExperiment view: ensure that the plugin is 'clean'

### DIFF
--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewplugin.cpp
@@ -181,22 +181,7 @@ bool SimulationExperimentViewPlugin::pluginInterfacesOk(const QString &pFileName
 
 void SimulationExperimentViewPlugin::initializePlugin()
 {
-    // Create our Simulation Experiment view widget
-
-    mViewWidget = new SimulationExperimentViewWidget(this, mSolverInterfaces,
-                                                     mDataStoreInterfaces,
-                                                     mCellmlEditingViewPlugins,
-                                                     mCellmlSimulationViewPlugins,
-                                                     mSedmlFileTypeInterface,
-                                                     mCombineFileTypeInterface,
-                                                     Core::mainWindow());
-
-    mViewWidget->setObjectName("SimulationExperimentViewWidget");
-
-    // Hide our Simulation Experiment view widget since it may not initially be
-    // shown in  our central widget
-
-    mViewWidget->setVisible(false);
+    // We don't handle this interface...
 }
 
 //==============================================================================
@@ -258,6 +243,23 @@ void SimulationExperimentViewPlugin::pluginsInitialized(const Plugins &pLoadedPl
                 mCombineFileTypeInterface = fileTypeInterface;
         }
     }
+
+    // Create our Simulation Experiment view widget
+
+    mViewWidget = new SimulationExperimentViewWidget(this, mSolverInterfaces,
+                                                     mDataStoreInterfaces,
+                                                     mCellmlEditingViewPlugins,
+                                                     mCellmlSimulationViewPlugins,
+                                                     mSedmlFileTypeInterface,
+                                                     mCombineFileTypeInterface,
+                                                     Core::mainWindow());
+
+    mViewWidget->setObjectName("SimulationExperimentViewWidget");
+
+    // Hide our Simulation Experiment view widget since it may not initially be
+    // shown in  our central widget
+
+    mViewWidget->setVisible(false);
 }
 
 //==============================================================================


### PR DESCRIPTION
This is to address a small issue reported by @alan-wu in PR #1362.