### PR TITLE
Ninja: pass arguments to `genericmake` onto ninja.

### DIFF
--- a/scripts/genericmake
+++ b/scripts/genericmake
@@ -42,7 +42,7 @@ if [ $exitCode -ne 0 ]; then
 fi
 
 if [ $ninjaFound = true ]; then
-    ninja
+    ninja $*
 else
     make $*
 fi


### PR DESCRIPTION
Then `./make TARGET` can be used to build the given target, a useful way to build a specific plugin (instead of `cd build` followed by `ninja TARGET`).