### PR TITLE
Minor code cleaning up.

### DIFF
--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
@@ -155,8 +155,8 @@ SimulationExperimentViewSimulationWidget::SimulationExperimentViewSimulationWidg
                                             QKeySequence(Qt::ControlModifier|Qt::Key_F2), mToolBarWidget);
     mResetModelParametersAction = Core::newAction(QIcon(":/oxygen/actions/view-refresh.png"),
                                                   mToolBarWidget);
-    mClearSimulationDataAction = Core::newAction(QIcon(":/oxygen/actions/trash-empty.png"),
-                                                 mToolBarWidget);
+    mClearSimulationResultsAction = Core::newAction(QIcon(":/oxygen/actions/trash-empty.png"),
+                                                    mToolBarWidget);
     mDevelopmentModeAction = Core::newAction(true, QIcon(":/oxygen/actions/run-build-configure.png"),
                                              mToolBarWidget);
     mAddGraphPanelAction = Core::newAction(QIcon(":/oxygen/actions/list-add.png"),
@@ -187,7 +187,7 @@ SimulationExperimentViewSimulationWidget::SimulationExperimentViewSimulationWidg
             this, &SimulationExperimentViewSimulationWidget::stopSimulation);
     connect(mResetModelParametersAction, &QAction::triggered,
             this, &SimulationExperimentViewSimulationWidget::resetModelParameters);
-    connect(mClearSimulationDataAction, &QAction::triggered,
+    connect(mClearSimulationResultsAction, &QAction::triggered,
             this, &SimulationExperimentViewSimulationWidget::clearSimulationResults);
     connect(mDevelopmentModeAction, &QAction::triggered,
             this, &SimulationExperimentViewSimulationWidget::developmentMode);
@@ -329,7 +329,7 @@ SimulationExperimentViewSimulationWidget::SimulationExperimentViewSimulationWidg
     mToolBarWidget->addAction(mStopSimulationAction);
     mToolBarWidget->addSeparator();
     mToolBarWidget->addAction(mResetModelParametersAction);
-    mToolBarWidget->addAction(mClearSimulationDataAction);
+    mToolBarWidget->addAction(mClearSimulationResultsAction);
     mToolBarWidget->addSeparator();
     mToolBarWidget->addWidget(mDelayWidget);
 #if defined(Q_OS_WIN) || defined(Q_OS_LINUX)
@@ -525,8 +525,8 @@ void SimulationExperimentViewSimulationWidget::retranslateUi()
                                      tr("Stop the simulation"));
     I18nInterface::retranslateAction(mResetModelParametersAction, tr("Reset Model Parameters"),
                                      tr("Reset all the model parameters"));
-    I18nInterface::retranslateAction(mClearSimulationDataAction, tr("Clear Simulation Data"),
-                                     tr("Clear the simulation data"));
+    I18nInterface::retranslateAction(mClearSimulationResultsAction, tr("Clear Simulation Results"),
+                                     tr("Clear the simulation result"));
     I18nInterface::retranslateAction(mDevelopmentModeAction, tr("Development Mode"),
                                      tr("Enable/disable the development mode"));
     I18nInterface::retranslateAction(mAddGraphPanelAction, tr("Add Graph Panel"),
@@ -645,8 +645,8 @@ void SimulationExperimentViewSimulationWidget::updateSimulationMode()
 
     // Enable/disable some actions
 
-    mClearSimulationDataAction->setEnabled(    mSimulation->results()->size()
-                                           && !simulationModeEnabled);
+    mClearSimulationResultsAction->setEnabled(    mSimulation->results()->size()
+                                              && !simulationModeEnabled);
     mSimulationDataExportAction->setEnabled(    mSimulationDataExportDropDownMenu->actions().count()
                                             &&  mSimulation->results()->size()
                                             && !simulationModeEnabled);

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
@@ -188,7 +188,7 @@ SimulationExperimentViewSimulationWidget::SimulationExperimentViewSimulationWidg
     connect(mResetModelParametersAction, &QAction::triggered,
             this, &SimulationExperimentViewSimulationWidget::resetModelParameters);
     connect(mClearSimulationDataAction, &QAction::triggered,
-            this, &SimulationExperimentViewSimulationWidget::clearSimulationData);
+            this, &SimulationExperimentViewSimulationWidget::clearSimulationResults);
     connect(mDevelopmentModeAction, &QAction::triggered,
             this, &SimulationExperimentViewSimulationWidget::developmentMode);
     connect(mAddGraphPanelAction, &QAction::triggered,
@@ -914,7 +914,7 @@ void SimulationExperimentViewSimulationWidget::initialize(bool pReloadingView)
         //       mode, so we are fine...
 
         if (pReloadingView)
-            clearSimulationData();
+            clearSimulationResults();
         else
             updateSimulationMode();
 
@@ -1364,9 +1364,9 @@ void SimulationExperimentViewSimulationWidget::resetModelParameters()
 
 //==============================================================================
 
-void SimulationExperimentViewSimulationWidget::clearSimulationData()
+void SimulationExperimentViewSimulationWidget::clearSimulationResults()
 {
-    // Clear our simulation data
+    // Clear our simulation results
     // Note: we temporarily disable updates to prevent the GUI from taking too
     //       long to update itself (something that might happen when we have
     //       several graph panels since they will try to realign themselves)...

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.h
@@ -185,7 +185,7 @@ private:
     QAction *mRunPauseResumeSimulationAction;
     QAction *mStopSimulationAction;
     QAction *mResetModelParametersAction;
-    QAction *mClearSimulationDataAction;
+    QAction *mClearSimulationResultsAction;
     QAction *mDevelopmentModeAction;
     QAction *mAddGraphPanelAction;
     QAction *mRemoveGraphPanelAction;

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.h
@@ -319,7 +319,7 @@ private slots:
     void removeCurrentGraphPanel();
     void removeAllGraphPanels();
     void resetModelParameters();
-    void clearSimulationData();
+    void clearSimulationResults();
     void sedmlExportSedmlFile();
     void sedmlExportCombineArchive();
 


### PR DESCRIPTION
This slot clears simulation results, not simulation parameters (which are known as `SimulationData`), so use an appropriate name.

Hmm, the corresponding action should also be renamed, along with its tooltip...