### PR TITLE
Different plot colours for successive runs

### DIFF
--- a/src/plugins/miscellaneous/Core/src/propertyeditorwidget.cpp
+++ b/src/plugins/miscellaneous/Core/src/propertyeditorwidget.cpp
@@ -1064,7 +1064,7 @@ void Property::setColorValue(const QColor &pColorValue)
 {
     // Set our value, should it be of color type
 
-    if (mType == Color) {
+    if (mType == Color && pColorValue.isValid()) {
         QString colorValueName = pColorValue.name(QColor::HexArgb);
 
         if (colorValueName.startsWith("#ff"))

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
@@ -2916,7 +2916,7 @@ bool SimulationExperimentViewSimulationWidget::furtherInitialize()
             QString title = QString();
             Qt::PenStyle lineStyle = Qt::SolidLine;
             double lineWidth = 1.0;
-            QColor lineColor = Qt::darkBlue;
+            QColor lineColor = QColor();
             QwtSymbol::Style symbolStyle = QwtSymbol::NoSymbol;
             int symbolSize = 8;
             QColor symbolColor = Qt::darkBlue;

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
@@ -1959,6 +1959,9 @@ bool SimulationExperimentViewSimulationWidget::createSedmlFile(SEDMLSupport::Sed
             Core::Properties lineProperties = properties[4]->properties();
             Core::Properties symbolProperties = properties[5]->properties();
 
+            QString lineColor = lineProperties[2]->valueAsString().isEmpty() ? ""
+                              : SedmlProperty.arg(SEDMLSupport::Color).arg(lineProperties[2]->valueAsString());
+
             sedmlCurve->appendAnnotation(QString("<%1 xmlns=\"%2\">"
                                                  "    %3"
                                                  "</%1>").arg(SEDMLSupport::Properties)
@@ -1970,8 +1973,7 @@ bool SimulationExperimentViewSimulationWidget::createSedmlFile(SEDMLSupport::Sed
                                                                                                .arg(SEDMLSupport::lineStyleValue(lineProperties[0]->listValueIndex()))
                                                                                  +SedmlProperty.arg(SEDMLSupport::Width)
                                                                                                .arg(lineProperties[1]->valueAsString())
-                                                                                 +SedmlProperty.arg(SEDMLSupport::Color)
-                                                                                               .arg(lineProperties[2]->valueAsString()))
+                                                                                 +lineColor)
                                                               +SedmlProperty.arg(SEDMLSupport::Symbol)
                                                                             .arg( SedmlProperty.arg(SEDMLSupport::Style)
                                                                                                .arg(SEDMLSupport::symbolStyleValue(symbolProperties[0]->listValueIndex()))

--- a/src/plugins/widget/GraphPanelWidget/src/graphpanelplotwidget.cpp
+++ b/src/plugins/widget/GraphPanelWidget/src/graphpanelplotwidget.cpp
@@ -195,6 +195,18 @@ static const QRectF InvalidRect = QRectF(0.0, 0.0, -1.0, -1.0);
 
 //==============================================================================
 
+QList<QColor> GraphPanelPlotGraph::RunColours =  {
+    QColor::fromRgb(0xe41a1c),
+    QColor::fromRgb(0x377eb8),
+    QColor::fromRgb(0x4daf4a),
+    QColor::fromRgb(0x984ea3),
+    QColor::fromRgb(0xff7f00),
+    QColor::fromRgb(0xffff33),
+    QColor::fromRgb(0xa65628),
+    QColor::fromRgb(0xf781bf)};
+
+//==============================================================================
+
 GraphPanelPlotGraph::GraphPanelPlotGraph(void *pParameterX, void *pParameterY) :
     mSelected(true),
     mFileName(QString()),
@@ -289,7 +301,11 @@ void GraphPanelPlotGraph::addRun()
         const QwtSymbol *symbol = mDummyRun->symbol();
         int symbolSize = symbol->size().width();
 
-        run->setPen(mDummyRun->pen());
+        auto runPen = QPen(mDummyRun->pen());
+        auto runColour = RunColours[mRuns.size() % RunColours.size()];
+        runPen.setColor(runColour);
+        run->setPen(runPen);
+
         run->setSymbol(new QwtSymbol(symbol->style(), symbol->brush(),
                                      symbol->pen(), QSize(symbolSize, symbolSize)));
         run->setTitle(mDummyRun->title());

--- a/src/plugins/widget/GraphPanelWidget/src/graphpanelplotwidget.cpp
+++ b/src/plugins/widget/GraphPanelWidget/src/graphpanelplotwidget.cpp
@@ -176,7 +176,7 @@ GraphPanelPlotGraphRun::GraphPanelPlotGraphRun(GraphPanelPlotGraph *pOwner) :
 
     setLegendAttribute(LegendShowLine);
     setLegendAttribute(LegendShowSymbol);
-    setPen(QPen(Qt::darkBlue, 1.0, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+    setPen(QPen(QColor(), 1.0, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
     setRenderHint(RenderAntialiased);
 }
 
@@ -302,8 +302,10 @@ void GraphPanelPlotGraph::addRun()
         int symbolSize = symbol->size().width();
 
         auto runPen = QPen(mDummyRun->pen());
-        auto runColour = RunColours[mRuns.size() % RunColours.size()];
-        runPen.setColor(runColour);
+        if (!runPen.color().isValid()) {
+            auto runColour = RunColours[mRuns.size() % RunColours.size()];
+            runPen.setColor(runColour);
+        }
         run->setPen(runPen);
 
         run->setSymbol(new QwtSymbol(symbol->style(), symbol->brush(),
@@ -441,13 +443,18 @@ void GraphPanelPlotGraph::setPen(const QPen &pPen)
 
     mDummyRun->setPen(pPen);
 
-    int runNumber = 0;
-    foreach (GraphPanelPlotGraphRun *run, mRuns) {
-        auto runPen = QPen(pPen);
-        auto runColour = RunColours[runNumber % RunColours.size()];
-        runPen.setColor(runColour);
-        run->setPen(runPen);
-        runNumber += 1;
+    if (pPen.color().isValid()) {
+        foreach (GraphPanelPlotGraphRun *run, mRuns)
+            run->setPen(pPen);
+    } else {
+        int runNumber = 0;
+        foreach (GraphPanelPlotGraphRun *run, mRuns) {
+            auto runPen = QPen(pPen);
+            auto runColour = RunColours[runNumber % RunColours.size()];
+            runPen.setColor(runColour);
+            run->setPen(runPen);
+            runNumber += 1;
+        }
     }
 }
 

--- a/src/plugins/widget/GraphPanelWidget/src/graphpanelplotwidget.cpp
+++ b/src/plugins/widget/GraphPanelWidget/src/graphpanelplotwidget.cpp
@@ -441,8 +441,14 @@ void GraphPanelPlotGraph::setPen(const QPen &pPen)
 
     mDummyRun->setPen(pPen);
 
-    foreach (GraphPanelPlotGraphRun *run, mRuns)
-        run->setPen(pPen);
+    int runNumber = 0;
+    foreach (GraphPanelPlotGraphRun *run, mRuns) {
+        auto runPen = QPen(pPen);
+        auto runColour = RunColours[runNumber % RunColours.size()];
+        runPen.setColor(runColour);
+        run->setPen(runPen);
+        runNumber += 1;
+    }
 }
 
 //==============================================================================

--- a/src/plugins/widget/GraphPanelWidget/src/graphpanelplotwidget.h
+++ b/src/plugins/widget/GraphPanelWidget/src/graphpanelplotwidget.h
@@ -69,7 +69,7 @@ public:
     explicit GraphPanelPlotGraphProperties(const QString &pTitle = QString(),
                                            const Qt::PenStyle &pLineStyle = Qt::SolidLine,
                                            int pLineWidth = 1,
-                                           const QColor &pLineColor = Qt::darkBlue,
+                                           const QColor &pLineColor = QColor(),
                                            const QwtSymbol::Style &pSymbolStyle = QwtSymbol::NoSymbol,
                                            int pSymbolSize = 8,
                                            const QColor &pSymbolColor = Qt::darkBlue,

--- a/src/plugins/widget/GraphPanelWidget/src/graphpanelplotwidget.h
+++ b/src/plugins/widget/GraphPanelWidget/src/graphpanelplotwidget.h
@@ -131,6 +131,8 @@ class GraphPanelPlotWidget;
 
 class GRAPHPANELWIDGET_EXPORT GraphPanelPlotGraph
 {
+    static QList<QColor> RunColours;
+
 public:
     explicit GraphPanelPlotGraph(void *pParameterX = 0, void *pParameterY = 0);
 


### PR DESCRIPTION
Here is my work on cycling through line colours on successive runs, although I suspect you will keep it for after the 0.6 release.

It uses an invalid `lineColor` value to indicate that the colour is to come from the `RunColours` sequence, indexed by run number. In a SED-ML file, lines without a colour have no <color> element (so get colours from the sequence) and those with one are shown as expected.

Future things could be to:
1. Allow a `colorProperty` to be cleared from the plot information widget -- at the moment the only way to remove a line's colour is by editing SED-ML.
2. Allow a user to define and/or select pre-defined colour sequences (via Preferences?).
3. Allow a user to set a default line colour or sequence (note that `QColor::darkBlue` was hard-coded in more than one place, which IMHO is not a good thing; I suspect the same might be true for the colours of other elements).