### PR TITLE
Prevent OpenCOR from crashing when selecting Tools | Reset All

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -337,6 +337,16 @@ MainWindow::MainWindow(const QString &pApplicationDate) :
 
 MainWindow::~MainWindow()
 {
+    // Stop tracking the showing/hiding of the different window widgets
+    // Note: indeed, to call updateDockWidgetsVisibility() when shutting down
+    //       (e.g. as a result of selecting Tools | Reset All) doesn't make
+    //       sense and will, in fact, crash OpenCOR...
+
+    foreach (Plugin *plugin, mLoadedWindowPlugins) {
+        disconnect(qobject_cast<WindowInterface *>(plugin->instance())->windowWidget(), &QDockWidget::visibilityChanged,
+                   this, &MainWindow::updateDockWidgetsVisibility);
+    }
+
     // Finalise our plugins
     // Note: we do this in reverse to ensure that dependent objects are deleted
     //       in the correct order...


### PR DESCRIPTION
It looks like this might (somehow?) be related to our use of the new signal/slot mechanism? At least, that seems to be the only difference between the 17 March and 23 April snapshots when it comes to MainWindow::updateDockWidgetsVisibility().