### PR TITLE
Python: make sure the path to our Python is updated in scripts.

### DIFF
--- a/src/plugins/thirdParty/Python/CMakeLists.txt
+++ b/src/plugins/thirdParty/Python/CMakeLists.txt
@@ -546,12 +546,15 @@ if(NOT "${DEPENDS_ON}" STREQUAL "")
     add_dependencies(${PROJECT_NAME} ${DEPENDS_ON})
 endif()
 
-# Copy a script to update the Python path in copied scripts and run it
+# Copy a script to update the Python path in copied scripts
+
+add_custom_command(OUTPUT ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${SCRIPT_DIR}/set_python_path.py
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/scripts/set_python_path.py
+                                     ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${SCRIPT_DIR})
+
+# And run it
 
 add_custom_command(TARGET PythonPlugin POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/scripts/set_python_path.py
-                                     ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${SCRIPT_DIR}
     COMMAND ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${PYTHON_EXECUTABLE}
                 ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${SCRIPT_DIR}/set_python_path.py
-                    ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR} -s
-    )
+                    ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR} -s)

--- a/src/plugins/thirdParty/Python/CMakeLists.txt
+++ b/src/plugins/thirdParty/Python/CMakeLists.txt
@@ -437,11 +437,13 @@ else()
         set(BUILT_PYTHON "LD_LIBRARY_PATH=${FULL_DEST_EXTERNAL_BINARIES_DIR}" ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/bin/python)
     endif()
 
+    # Install the Python package manager and dependencies
+
     if(WIN32)
-        # On Windows, we need to explicitly install setuptools, pip and wheel in
-        # order to create *-script-py files that can then be modified during the
-        # installation of OpenCOR, so that they reference our newly installed
-        # Python executable
+        # On Windows, we use our version of pip that is modified to
+        # create `*-script.py` files when installing packaages with
+        # console scripts, so that they can then be updated to
+        # reference OpenCOR's Python executable.
 
         # Install the Python setuptools package
 
@@ -457,7 +459,7 @@ else()
             INSTALL_DIR
                 ${SETUPTOOLS_SOURCE_DIR}
             GIT_REPOSITORY
-                https://github.com/opencor/setuptools.git
+                https://github.com/pypa/setuptools.git
             GIT_TAG
                 ${SETUPTOOLS_GIT_TAG}
             CONFIGURE_COMMAND
@@ -470,7 +472,7 @@ else()
                 ${PACKAGE_BUILD}
         )
 
-        # Install the Python package installer
+        # Install our Python package installer
 
         set(PIP_SOURCE_DIR ${PROJECT_SOURCE_DIR}/ext/pip)
 
@@ -486,7 +488,7 @@ else()
             GIT_REPOSITORY
                 https://github.com/opencor/pip.git
             GIT_TAG
-                ${PIP_GIT_TAG}
+                opencor_v${PIP_GIT_TAG}
             CONFIGURE_COMMAND
                 ""
             BUILD_COMMAND
@@ -497,44 +499,14 @@ else()
                 installSetuptools
         )
 
-        # Install the wheel Python package
-
-        set(WHEEL_SOURCE_DIR ${PROJECT_SOURCE_DIR}/ext/wheel)
-
-        ExternalProject_Add(installWheel
-            DOWNLOAD_DIR
-                ${WHEEL_SOURCE_DIR}
-            SOURCE_DIR
-                ${WHEEL_SOURCE_DIR}
-            BINARY_DIR
-                ${WHEEL_SOURCE_DIR}
-            INSTALL_DIR
-                ${WHEEL_SOURCE_DIR}
-            GIT_REPOSITORY
-                https://github.com/opencor/wheel.git
-            GIT_TAG
-                ${WHEEL_GIT_TAG}
-            CONFIGURE_COMMAND
-                ""
-            BUILD_COMMAND
-                ${BUILT_PYTHON} setup.py build
-            INSTALL_COMMAND
-                ${BUILT_PYTHON} setup.py install
-            DEPENDS
-                installPip
-        )
-
-        set(CREATE_PACKAGE_TARGET installWheel)
+        set(CREATE_PACKAGE_TARGET installPip)
     else()
-        # On Linux and macOS, install the Python package manager, wheel, and
-        # dependencies
-
         ExternalProject_Add_Step(${PACKAGE_BUILD} installPip
-                                 COMMAND ${BUILT_PYTHON} -s ${PROJECT_SOURCE_DIR}/scripts/get-pip.py
+                                 COMMAND ${BUILT_PYTHON} -s ${PROJECT_SOURCE_DIR}/scripts/get-pip.py --no-wheel
                                  WORKING_DIRECTORY ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/bin
                                  DEPENDEES cleanSitePackagesDirectory)
 
-        set(CREATE_PACKAGE_TARGET ${PACKAGE_BUILD})
+        set(CREATE_PACKAGE_TARGET installPip)
     endif()
 
     # Package Python's include files and libraries
@@ -573,3 +545,13 @@ add_dependencies(OpenCORBuild ${PROJECT_NAME})
 if(NOT "${DEPENDS_ON}" STREQUAL "")
     add_dependencies(${PROJECT_NAME} ${DEPENDS_ON})
 endif()
+
+# Copy a script to update the Python path in copied scripts and run it
+
+add_custom_command(TARGET PythonPlugin POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/scripts/set_python_path.py
+                                     ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${SCRIPT_DIR}
+    COMMAND ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${PYTHON_EXECUTABLE}
+                ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${SCRIPT_DIR}/set_python_path.py
+                    ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR} -s
+    )

--- a/src/plugins/thirdParty/Python/CMakeLists.txt
+++ b/src/plugins/thirdParty/Python/CMakeLists.txt
@@ -114,14 +114,14 @@ endif()
 # Add headers, scripts and libraries to the package archive
 
 set(PACKAGED_FILES
+    bin
     include
     ${RUNTIME_DIR}
-    ${SCRIPT_DIR}
     ${SHA1_FILES}
 )
 
 if(WIN32)
-    list(APPEND PACKAGED_FILES Scripts)
+    list(APPEND PACKAGED_FILES ${SCRIPT_DIR})
 elseif()
     list(APPEND PACKAGED_FILES ${RUNTIME_DIR}/config-${PYTHON_BUILT_VERSION})
 endif()
@@ -137,22 +137,22 @@ if(USE_PREBUILT_PYTHON_PACKAGE)
     if(WIN32)
         if(RELEASE_MODE)
             retrieve_package_file(${PACKAGE_NAME} ${PACKAGE_VERSION}
-                                  ${RELATIVE_PROJECT_SOURCE_DIR} c99e62188b191a6fc8bed55e6ec6303cf112223c
+                                  ${RELATIVE_PROJECT_SOURCE_DIR} 201c3a0a7621901c7c5da8c121aabff69800ab93
                                   SHA1_FILES ${SHA1_FILES}
-                                  SHA1_VALUES 7cc5560a76bf97f9bf5d415f36f46fdc53b21957
-                                              d157939f61d9ed5506fc5cf876fcec39c41924a3
-                                              a7c7246f8ee95c8039ae4220ba61bbda2308fad3
+                                  SHA1_VALUES b45336c90f5a8d39067c8873c46eed73e0596d82
+                                              1fb636519bc0d86f181febbac697c842945f645b
+                                              41fcf7de51b0150cb5d526696ab4ea6943fff4aa
                                               3f54413d619bdc17271c9dc6b9cf0b2ed5df4e17
-                                              c73d9f185b186d00a34c84345b3b3541c156a421)
+                                              b9d15e7df553a66f8f0a42f27016ff878051196d)
         else()
             retrieve_package_file(${PACKAGE_NAME} ${PACKAGE_VERSION}
-                                  ${RELATIVE_PROJECT_SOURCE_DIR} 1d8c126dc5cc4c17b0a487f1b5bc899340fbd954
+                                  ${RELATIVE_PROJECT_SOURCE_DIR} 1651cf41ba9aca0767eecdea908d34217ec653ce
                                   SHA1_FILES ${SHA1_FILES}
-                                  SHA1_VALUES 71cba1a8dedb5533daa303b2f796d840f7fbc764
-                                              2763cb98d5b09e623d1c3dfa060eec8720883ecf
-                                              8ad14e1441b92c84b27d6b3f469e284653fe0b91
+                                  SHA1_VALUES eaec9798ba6c5a1bf4b1cc161b6c7dfc59d1ea80
+                                              6e79fbfa322c9c56189932c9d6007b9e1f55d3af
+                                              c0d0bd4c50ad3f0760b95696d50abe9336ecfe6c
                                               3f54413d619bdc17271c9dc6b9cf0b2ed5df4e17
-                                              164b0decaac36ba4fba601023b0669f2443f9e7b)
+                                              41e1905467d98d2f0ddfdb273795dfac9e3402f7)
         endif()
     elseif(APPLE)
         retrieve_package_file(${PACKAGE_NAME} ${PACKAGE_VERSION}

--- a/src/plugins/thirdParty/Python/CMakeLists.txt
+++ b/src/plugins/thirdParty/Python/CMakeLists.txt
@@ -548,9 +548,8 @@ endif()
 
 # Copy a script to update the Python path in copied scripts
 
-add_custom_command(OUTPUT ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${SCRIPT_DIR}/set_python_path.py
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/scripts/set_python_path.py
-                                     ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${SCRIPT_DIR})
+file(COPY ${PROJECT_SOURCE_DIR}/scripts/set_python_path.py
+     DESTINATION ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${SCRIPT_DIR})
 
 # And run it
 

--- a/src/plugins/thirdParty/Python/scripts/set_python_path.py
+++ b/src/plugins/thirdParty/Python/scripts/set_python_path.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+"""
+    Based on `move-virtualenv`, updated for Python 3 and Windows with
+    activation script processing removed.
+
+    =======================================================================
+
+    move-virtualenv`, a helper script that moves virtualenvs to a new
+    location. https://github.com/fireteam/virtualenv-tools.
+
+    Copyright (c) 2012 by Fireteam Ltd., see AUTHORS for more details.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+
+        * Redistributions in binary form must reproduce the above
+          copyright notice, this list of conditions and the following
+          disclaimer in the documentation and/or other materials provided
+          with the distribution.
+
+        * The names of the contributors may not be used to endorse or
+          promote products derived from this software without specific
+          prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+    =======================================================================
+"""
+import os
+import re
+import sys
+import logging
+import marshal
+import argparse
+import subprocess
+from types import CodeType
+from collections import OrderedDict
+
+windows = (os.name == 'nt')
+
+python_exe = 'python.exe' if windows else 'python'
+path_slash = '\\' if windows else '/'
+bin_python = path_slash + 'bin' + path_slash + python_exe
+
+_pybin_match = re.compile(r'^python\d+\.\d+$')
+
+def update_script(script_filename, new_path, clear_args, extra_args):
+    """Updates shebang lines for actual scripts."""
+    try:
+        with open(script_filename, 'r') as f:
+            lines = list(f)
+    except (IsADirectoryError, UnicodeDecodeError, PermissionError):
+        return
+
+    if not lines:
+        return
+
+    if not lines[0].startswith('#!'):
+        return
+
+    line = lines[0][2:]
+    if line[0] in ['"', "'"]:
+        has_quote = True
+        quote = line[0]
+        end = line[1:].index(quote) + 1
+        args = [line[1:end]] + line[end+1:].split()
+    else:
+        has_quote = False
+        quote = '"'
+        args = line.strip().split()
+
+    if not args:
+        return
+
+    if not args[0].endswith(bin_python) \
+    or '/usr/bin/env python' in args[0]:
+        return
+
+    if clear_args: del args[1:]
+    arg_set = OrderedDict([(a, None) for a in args[1:]])
+    arg_set.update(OrderedDict([(a, None) for a in extra_args]))
+    new_args = list(arg_set.keys())
+
+    add_quote = (' ' in new_path)
+    new_bin = os.path.join(new_path, 'bin', python_exe)
+    if new_bin == args[0] and has_quote == add_quote and new_args == args[1:]:
+        return
+
+    if add_quote:
+        args[0] = '%s%s%s' % (quote, new_bin, quote)
+    else:
+        args[0] = new_bin
+    args[1:] = new_args
+
+    logging.info('S: %s', script_filename)
+    lines[0] = '#!%s\n' % ' '.join(args)
+    with open(script_filename, 'w') as f:
+        f.writelines(lines)
+
+
+def update_scripts(bin_dir, new_path, clear_args, extra_args):
+    """Updates all scripts in the bin folder."""
+    for fn in os.listdir(bin_dir):
+        update_script(os.path.join(bin_dir, fn), new_path, clear_args, extra_args)
+
+
+def update_pyc(filename, new_path):
+    """Updates the filenames stored in pyc files."""
+    with open(filename, 'rb') as f:
+        if sys.version_info < (3, 3): magic = f.read(8)
+        else:                         magic = f.read(12)
+        code = marshal.loads(f.read())
+
+    def _make_code(code, filename, consts):
+        return CodeType(code.co_argcount, code.co_kwonlyargcount, code.co_nlocals,
+                        code.co_stacksize, code.co_flags, code.co_code,
+                        tuple(consts), code.co_names, code.co_varnames, filename,
+                        code.co_name, code.co_firstlineno, code.co_lnotab,
+                        code.co_freevars, code.co_cellvars)
+
+    def _process(code):
+        new_filename = new_path
+        consts = []
+        for const in code.co_consts:
+            if type(const) is CodeType:
+                const = _process(const)
+            consts.append(const)
+        if new_path != code.co_filename or consts != list(code.co_consts):
+            code = _make_code(code, new_path, consts)
+        return code
+
+    new_code = _process(code)
+
+    if new_code is not code:
+        logging.info('B: %s', filename)
+        with open(filename, 'wb') as f:
+            f.write(magic)
+            marshal.dump(new_code, f)
+
+
+def update_pycs(lib_dir, new_path, lib_name):
+    """Walks over all pyc files and updates their paths."""
+    files = []
+
+    def get_new_path(filename):
+        filename = os.path.normpath(filename)
+        if filename.startswith(lib_dir.rstrip('/') + '/'):
+            return os.path.join(new_path, filename[len(lib_dir) + 1:])
+
+    for dirname, dirnames, filenames in os.walk(lib_dir):
+        for filename in filenames:
+            filename = os.path.join(dirname, filename)
+            if (filename.endswith(('.pyc', '.pyo'))
+            and not os.path.dirname(filename).endswith('__pycache__')):
+                local_path = get_new_path(filename)
+                if local_path is not None:
+                    update_pyc(filename, local_path)
+
+
+def update_paths(base, scripts_dir, clear_args, extra_args):
+    """Updates all paths in a virtualenv to a new one."""
+    new_path = os.path.abspath(base)
+    bin_dir = os.path.join(base, 'bin')
+    lib_dir = None
+    lib_name = None
+
+    if scripts_dir == 'auto':
+        if windows:
+            scripts_dir = os.path.join(base, 'Scripts')
+        else:
+            scripts_dir = bin_dir
+
+    if windows:
+        base_lib_dir = base
+        lib_name = 'Lib'
+    else:
+        base_lib_dir = os.path.join(base, 'lib')
+        if os.path.isdir(base_lib_dir):
+            for folder in os.listdir(base_lib_dir):
+                if _pybin_match.match(folder):
+                    lib_name = folder
+                    break
+
+    if (lib_name is None
+     or not os.path.isdir(scripts_dir)
+     or not os.path.isdir(bin_dir)
+     or not os.path.isfile(os.path.join(bin_dir, python_exe))):
+        print('error: %s does not refer to a Python installation' % base)
+        return False
+
+    lib_dir = os.path.join(base_lib_dir, lib_name)
+
+    update_scripts(scripts_dir, new_path, clear_args, extra_args)
+    update_pycs(lib_dir, new_path, lib_name)
+
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Update the path of scripts '
+                                                 'to a new Python prefix')
+
+    parser.add_argument('-c', '--clear-args', dest='clear_args',
+                        default=False, action='store_true',
+                        help='Clear all existing arguments to Python')
+
+    parser.add_argument('-u', '--update-path', dest='update_path',
+                        help='Path to scripts. Set to "auto" for autodetection')
+
+    parser.add_argument('-v', '--verbose', dest='verbose',
+                        default=False, action='store_true',
+                        help='Show names of updated scripts')
+
+    parser.add_argument('path', metavar='PATH', help='Path to new Python installation.')
+
+    parser.add_argument('extra_args', metavar='ARGS', nargs=argparse.REMAINDER,
+                        help='Additional arguments to append to Python')
+
+    args = parser.parse_args()
+    if not args.update_path:
+        args.update_path = 'auto'
+
+    if not args.verbose:
+        logging.disable(logging.INFO)
+
+    sys.exit(0 if update_paths(args.path, args.update_path, args.clear_args, args.extra_args) else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/plugins/thirdParty/PythonPackages/CMakeLists.txt
+++ b/src/plugins/thirdParty/PythonPackages/CMakeLists.txt
@@ -58,14 +58,14 @@ if(USE_PREBUILT_PYTHON_PACKAGE AND USE_PREBUILT_PYTHON_PACKAGES_PACKAGE)
     if(WIN32)
         if(RELEASE_MODE)
             retrieve_package_file(${PACKAGE_NAME} ${PACKAGE_VERSION}
-                                  ${RELATIVE_PROJECT_SOURCE_DIR} 4b980929824fbb9324eba6db221396cd4fd30b32
+                                  ${RELATIVE_PROJECT_SOURCE_DIR} 9f950862b63ccf386e47be21a8a2da3c68687b9f
                                   PACKAGE_REPOSITORY ${PACKAGE_REPOSITORY}
                                   RELEASE_TAG ${RELEASE_TAG}
                                   SHA1_FILES ${SHA1_FILES}
                                   SHA1_VALUES 3483da0d92f6b154ff7ce699350e741da0a84104)
         else()
             retrieve_package_file(${PACKAGE_NAME} ${PACKAGE_VERSION}
-                                  ${RELATIVE_PROJECT_SOURCE_DIR} c5d302fda38d1f94a29a7eb8ca5211e6067c59c8
+                                  ${RELATIVE_PROJECT_SOURCE_DIR} 077f8f0f162fe54d1d4743b4ad43869d3683b8c7
                                   PACKAGE_REPOSITORY ${PACKAGE_REPOSITORY}
                                   RELEASE_TAG ${RELEASE_TAG}
                                   SHA1_FILES ${SHA1_FILES}

--- a/src/plugins/thirdParty/PythonPackages/CMakeLists.txt
+++ b/src/plugins/thirdParty/PythonPackages/CMakeLists.txt
@@ -29,12 +29,13 @@ set(FULL_LOCAL_EXTERNAL_PACKAGE_DIR ${PROJECT_SOURCE_DIR}/${LOCAL_EXTERNAL_PACKA
 
 # Where Python packages are installed
 
-set(LOCAL_SITE_PACKAGES_DIR ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${PYTHON_RELATIVE_RUNTIME_DIR}/site-packages)
+set(LOCAL_SITE_PACKAGES_DIR ${PYTHON_RELATIVE_RUNTIME_DIR}/site-packages)
+set(FULL_LOCAL_SITE_PACKAGES_DIR ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${LOCAL_SITE_PACKAGES_DIR})
 
 # Directories we package
 
 set(PACKAGED_FILES
-    ${PYTHON_RELATIVE_RUNTIME_DIR}/site-packages
+    ${LOCAL_SITE_PACKAGES_DIR}
     ${PYTHON_RELATIVE_SCRIPT_DIR}
 )
 
@@ -42,7 +43,7 @@ set(PACKAGED_FILES
 # Note: at least one file must have its SHA-1 value checked...
 
 set(SHA1_FILES
-    ${PYTHON_RELATIVE_RUNTIME_DIR}/site-packages/sphinx/cmdline.py
+    ${LOCAL_SITE_PACKAGES_DIR}/sphinx/cmdline.py
 )
 
 # Use the pre-built version of our package unless instructed otherwise
@@ -98,41 +99,28 @@ else()
 
     # Ensure local site packages directory exists
 
-    file(MAKE_DIRECTORY ${LOCAL_SITE_PACKAGES_DIR})
+    file(MAKE_DIRECTORY ${FULL_LOCAL_SITE_PACKAGES_DIR})
 
     # Use our installed pip
 
     file(TO_NATIVE_PATH ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR} FULL_LOCAL_EXTERNAL_PACKAGE_PREFIX)
 
     set(PIP_INSTALL_COMMAND
-        ${CMAKE_COMMAND} -E env "PYTHONPATH=${LOCAL_SITE_PACKAGES_DIR}"
+        ${CMAKE_COMMAND} -E env "PYTHONPATH=${FULL_LOCAL_SITE_PACKAGES_DIR}"
         ${PYTHON_EXECUTABLE} -s -m
         pip install --prefix ${FULL_LOCAL_EXTERNAL_PACKAGE_PREFIX}
-                    --upgrade --upgrade-strategy only-if-needed)
+                    --upgrade --upgrade-strategy only-if-needed
+                    --no-warn-script-location)
 
     # Install Sphinx
 
-    if(WIN32)
-        # On Windows, we need to explicitly install Sphinx to create *-script-py
-        # files that can then be modified during the installation of OpenCOR, so
-        # that they reference our newly installed Python executable
-
-        add_custom_target(installSphinx
-            COMMAND ${PIP_INSTALL_COMMAND}
-                https://github.com/opencor/sphinx/archive/v${SPHINX_VERSION}.tar.gz
-            WORKING_DIRECTORY
-                ${FULL_DEST_EXTERNAL_BINARIES_DIR}
-            VERBATIM
-        )
-    else()
-        add_custom_target(installSphinx
-            COMMAND ${PIP_INSTALL_COMMAND} --only-binary all
-                sphinx==${SPHINX_VERSION}
-            WORKING_DIRECTORY
-                ${FULL_DEST_EXTERNAL_BINARIES_DIR}
-            VERBATIM
-        )
-    endif()
+    add_custom_target(installSphinx
+        COMMAND ${PIP_INSTALL_COMMAND} --only-binary all
+            sphinx==${SPHINX_VERSION}
+        WORKING_DIRECTORY
+            ${FULL_DEST_EXTERNAL_BINARIES_DIR}
+        VERBATIM
+    )
 
     add_dependencies(${PACKAGE_BUILD} installSphinx)
     add_dependencies(installSphinx ${BUILD_DEPENDENCIES})
@@ -159,7 +147,7 @@ else()
 endif()
 
 set(SPHINX_BUILD_EXECUTABLE
-    ${CMAKE_COMMAND} -E env "PYTHONPATH=${LOCAL_SITE_PACKAGES_DIR}"
+    ${CMAKE_COMMAND} -E env "PYTHONPATH=${FULL_LOCAL_SITE_PACKAGES_DIR}"
     ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${PYTHON_RELATIVE_SCRIPT_DIR}/${SPHINX_BUILD_EXECUTABLE} PARENT_SCOPE
 )
 
@@ -173,3 +161,11 @@ add_dependencies(OpenCORBuild ${PROJECT_NAME})
 if(NOT "${DEPENDS_ON}" STREQUAL "")
     add_dependencies(${PROJECT_NAME} ${DEPENDS_ON})
 endif()
+
+# Update the Python path in newly copied scripts
+
+add_custom_command(TARGET PythonPackagesPlugin POST_BUILD
+    COMMAND ${PYTHON_EXECUTABLE} ${PYTHON_SCRIPT_DIR}/set_python_path.py
+                --update-path ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${PYTHON_RELATIVE_SCRIPT_DIR}
+                ${PYTHON_ROOT_DIR} -s
+    )


### PR DESCRIPTION
@agarny, this PR merges in code from the [pythonplugin](https://github.com/dbrnz/opencor/tree/pythonplugin) branch to fix the issue you raised in your email, namely:

> I tried to use the OpenCOR version of Sphinx to build the OpenCOR documentation, but to no avail. On further investigation, I noticed that your `sphinx-build` script contains a hard-coded path:
```
#!/Users/dave/build/OpenCOR/src/plugins/thirdParty/Python/ext/bin/python
# -*- coding: utf-8 -*-

import re
import sys

from sphinx.cmd.build import main

if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
    sys.exit(main())
```
> I was able to fix the problem by hard-coding a path that works on my system, but we clearly need a solution that is system-independent. Any ideas?... (You might want to look for other similar instances.)
