### PR TITLE
Main window: removed `&` from different menu items

### DIFF
--- a/i18n/OpenCOR_fr.ts
+++ b/i18n/OpenCOR_fr.ts
@@ -34,28 +34,24 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <source>&amp;File</source>
-        <translation>&amp;Fichier</translation>
+        <source>File</source>
+        <translation>Fichier</translation>
     </message>
     <message>
-        <source>&amp;Tools</source>
-        <translation>Ou&amp;tils</translation>
+        <source>Tools</source>
+        <translation>Outils</translation>
     </message>
     <message>
-        <source>&amp;Language</source>
-        <translation>&amp;Langage</translation>
+        <source>Language</source>
+        <translation>Langage</translation>
     </message>
     <message>
-        <source>&amp;Help</source>
-        <translation>&amp;?</translation>
+        <source>Help</source>
+        <translation>?</translation>
     </message>
     <message>
-        <source>&amp;View</source>
-        <translation>&amp;Voir</translation>
-    </message>
-    <message>
-        <source>&amp;Quit</source>
-        <translation>&amp;Quitter</translation>
+        <source>View</source>
+        <translation>Voir</translation>
     </message>
     <message>
         <source>Quit</source>
@@ -66,80 +62,76 @@
         <translation>Quitter OpenCOR</translation>
     </message>
     <message>
-        <source>&amp;English</source>
-        <translation>&amp;Anglais</translation>
+        <source>English</source>
+        <translation>Anglais</translation>
     </message>
     <message>
         <source>Select English as the language to be used by OpenCOR</source>
         <translation>Sélectionner l&apos;anglais comme langue à être utilisée par OpenCOR</translation>
     </message>
     <message>
-        <source>&amp;French</source>
-        <translation>&amp;Français</translation>
+        <source>French</source>
+        <translation>Français</translation>
     </message>
     <message>
         <source>Select French as the language to be used by OpenCOR</source>
         <translation>Sélectionner le français comme langue à être utilisée par OpenCOR</translation>
     </message>
     <message>
-        <source>Home &amp;Page</source>
-        <translation>&amp;Page D&apos;Accueil</translation>
+        <source>Home Page</source>
+        <translation>Page D&apos;Accueil</translation>
     </message>
     <message>
         <source>Open the OpenCOR home page</source>
         <translation>Ouvrir la page d&apos;accueil d&apos;OpenCOR</translation>
     </message>
     <message>
-        <source>&amp;About...</source>
-        <translation>&amp;À Propos...</translation>
+        <source>About...</source>
+        <translation>À Propos...</translation>
     </message>
     <message>
         <source>Some general information about OpenCOR</source>
         <translation>Quelques informations générales sur OpenCOR</translation>
     </message>
     <message>
-        <source>&amp;Reset All</source>
-        <translation>Tout &amp;Réinitialiser</translation>
+        <source>Reset All</source>
+        <translation>Tout Réinitialiser</translation>
     </message>
     <message>
         <source>Reset all your settings</source>
         <translation>Réinitialiser tous vos paramètres</translation>
     </message>
     <message>
-        <source>&amp;System</source>
-        <translation>&amp;Système</translation>
+        <source>System</source>
+        <translation>Système</translation>
     </message>
     <message>
         <source>Select your system&apos;s language as the language to be used by OpenCOR</source>
         <translation>Sélectionner la langue de votre système comme langue à être utilisée par OpenCOR</translation>
     </message>
     <message>
-        <source>&amp;Full Screen</source>
-        <translation>&amp;Plein Ecran</translation>
+        <source>Full Screen</source>
+        <translation>Plein Ecran</translation>
     </message>
     <message>
         <source>Switch to / back from full screen mode</source>
         <translation>Passer au / revenir du mode plein écran</translation>
     </message>
     <message>
-        <source>Status &amp;Bar</source>
-        <translation>&amp;Barre D&apos;État</translation>
+        <source>Status Bar</source>
+        <translation>Barre D&apos;État</translation>
     </message>
     <message>
         <source>Show/hide the status bar</source>
         <translation>Montrer/cacher la barre d&apos;état</translation>
     </message>
     <message>
-        <source>Plu&amp;gins...</source>
-        <translation>E&amp;xtensions...</translation>
+        <source>Plugins...</source>
+        <translation>Extensions...</translation>
     </message>
     <message>
         <source>Un/select plugins</source>
         <translation>Dé/sélectionner des extensions</translation>
-    </message>
-    <message>
-        <source>&amp;Docked Windows</source>
-        <translation>&amp;Fenêtres Ancrées</translation>
     </message>
     <message>
         <source>Docked Windows</source>
@@ -150,8 +142,8 @@
         <translation>Montrer/cacher toutes les fenêtres ancrées récentes/actuelles</translation>
     </message>
     <message>
-        <source>&amp;Preferences...</source>
-        <translation>&amp;Préférences...</translation>
+        <source>Preferences...</source>
+        <translation>Préférences...</translation>
     </message>
     <message>
         <source>Preferences</source>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -22,17 +22,17 @@
    </property>
    <widget class="QMenu" name="menuFile">
     <property name="title">
-     <string>&amp;File</string>
+     <string>File</string>
     </property>
     <addaction name="actionQuit"/>
    </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
-     <string>&amp;Tools</string>
+     <string>Tools</string>
     </property>
     <widget class="QMenu" name="menuLanguage">
      <property name="title">
-      <string>&amp;Language</string>
+      <string>Language</string>
      </property>
      <property name="icon">
       <iconset resource="../res/ui.qrc">
@@ -53,7 +53,7 @@
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
-     <string>&amp;Help</string>
+     <string>Help</string>
     </property>
     <addaction name="actionHomePage"/>
     <addaction name="separator"/>
@@ -63,7 +63,7 @@
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
-     <string>&amp;View</string>
+     <string>View</string>
     </property>
     <addaction name="actionDockedWindows"/>
     <addaction name="separator"/>
@@ -83,7 +83,7 @@
      <normaloff>:/oxygen/actions/application-exit.png</normaloff>:/oxygen/actions/application-exit.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Quit</string>
+    <string>Quit</string>
    </property>
    <property name="toolTip">
     <string>Quit</string>
@@ -104,7 +104,7 @@
      <normaloff>:/flags/gb.png</normaloff>:/flags/gb.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;English</string>
+    <string>English</string>
    </property>
    <property name="statusTip">
     <string>Select English as the language to be used by OpenCOR</string>
@@ -122,7 +122,7 @@
      <normaloff>:/flags/fr.png</normaloff>:/flags/fr.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;French</string>
+    <string>French</string>
    </property>
    <property name="statusTip">
     <string>Select French as the language to be used by OpenCOR</string>
@@ -137,7 +137,7 @@
      <normaloff>:/oxygen/categories/applications-internet.png</normaloff>:/oxygen/categories/applications-internet.png</iconset>
    </property>
    <property name="text">
-    <string>Home &amp;Page</string>
+    <string>Home Page</string>
    </property>
    <property name="statusTip">
     <string>Open the OpenCOR home page</string>
@@ -152,7 +152,7 @@
      <normaloff>:/oxygen/actions/help-about.png</normaloff>:/oxygen/actions/help-about.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;About...</string>
+    <string>About...</string>
    </property>
    <property name="statusTip">
     <string>Some general information about OpenCOR</string>
@@ -167,7 +167,7 @@
      <normaloff>:/oxygen/actions/system-reboot.png</normaloff>:/oxygen/actions/system-reboot.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Reset All</string>
+    <string>Reset All</string>
    </property>
    <property name="statusTip">
     <string>Reset all your settings</string>
@@ -181,7 +181,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>&amp;System</string>
+    <string>System</string>
    </property>
    <property name="statusTip">
     <string>Select your system's language as the language to be used by OpenCOR</string>
@@ -196,7 +196,7 @@
      <normaloff>:/oxygen/actions/view-fullscreen.png</normaloff>:/oxygen/actions/view-fullscreen.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Full Screen</string>
+    <string>Full Screen</string>
    </property>
    <property name="statusTip">
     <string>Switch to / back from full screen mode</string>
@@ -207,7 +207,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Status &amp;Bar</string>
+    <string>Status Bar</string>
    </property>
    <property name="statusTip">
     <string>Show/hide the status bar</string>
@@ -219,7 +219,7 @@
      <normaloff>:/oxygen/apps/preferences-plugin.png</normaloff>:/oxygen/apps/preferences-plugin.png</iconset>
    </property>
    <property name="text">
-    <string>Plu&amp;gins...</string>
+    <string>Plugins...</string>
    </property>
    <property name="statusTip">
     <string>Un/select plugins</string>
@@ -230,7 +230,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>&amp;Docked Windows</string>
+    <string>Docked Windows</string>
    </property>
    <property name="iconText">
     <string>Docked Windows</string>
@@ -248,7 +248,7 @@
      <normaloff>:/oxygen/categories/preferences-system.png</normaloff>:/oxygen/categories/preferences-system.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Preferences...</string>
+    <string>Preferences...</string>
    </property>
    <property name="toolTip">
     <string>Preferences</string>


### PR DESCRIPTION
Hopefully, they don’t get used. Indeed, the reason for removing those
`&` is that it makes it much faster to create snapshots on Windows by
pressing Alt+PrtScn. However, with `&` in our main menu items, it meant
that the characters used as a shortcut (i.e. Alt+Char) were underlined,
which is not what we want…