### PR TITLE
Improve our threaded code

### DIFF
--- a/src/plugins/dataStore/BioSignalMLDataStore/i18n/BioSignalMLDataStore_fr.ts
+++ b/src/plugins/dataStore/BioSignalMLDataStore/i18n/BioSignalMLDataStore_fr.ts
@@ -40,7 +40,7 @@
     </message>
 </context>
 <context>
-    <name>OpenCOR::BioSignalMLDataStore::BiosignalmlDataStoreExporter</name>
+    <name>OpenCOR::BioSignalMLDataStore::BiosignalmlDataStoreExporterWorker</name>
     <message>
         <source>The data could not be exported to BioSignalML (%1).</source>
         <translation>Les données n&apos;ont pas pu être exportées vers BioSignalML (%1).</translation>

--- a/src/plugins/dataStore/BioSignalMLDataStore/src/biosignalmldatastoreexporter.cpp
+++ b/src/plugins/dataStore/BioSignalMLDataStore/src/biosignalmldatastoreexporter.cpp
@@ -44,14 +44,14 @@ namespace BioSignalMLDataStore {
 
 //==============================================================================
 
-BiosignalmlDataStoreExporter::BiosignalmlDataStoreExporter(DataStore::DataStoreData *pDataStoreData) :
-    DataStore::DataStoreExporter(pDataStoreData)
+BiosignalmlDataStoreExporterWorker::BiosignalmlDataStoreExporterWorker(DataStore::DataStoreData *pDataStoreData) :
+    DataStore::DataStoreExporterWorker(pDataStoreData)
 {
 }
 
 //==============================================================================
 
-void BiosignalmlDataStoreExporter::execute(QString &pErrorMessage) const
+void BiosignalmlDataStoreExporterWorker::run()
 {
     // Determine the number of steps to export everything
 
@@ -69,6 +69,7 @@ void BiosignalmlDataStoreExporter::execute(QString &pErrorMessage) const
     // Export the given data store to a BioSignalML file
 
     bsml::HDF5::Recording *recording = nullptr;
+    QString errorMessage = QString();
 
     try {
         // Create and populate a recording
@@ -161,7 +162,7 @@ void BiosignalmlDataStoreExporter::execute(QString &pErrorMessage) const
         // Something went wrong, so retrieve the error message and delete our
         // BioSignalML file
 
-        pErrorMessage = tr("The data could not be exported to BioSignalML (%1).").arg(exception.what());
+        errorMessage = tr("The data could not be exported to BioSignalML (%1).").arg(exception.what());
 
         QFile::remove(dataStoreData->fileName());
     }
@@ -173,6 +174,19 @@ void BiosignalmlDataStoreExporter::execute(QString &pErrorMessage) const
 
         delete recording;
     }
+
+    // Let people know that our XSL transformation has been performed
+
+    emit done(errorMessage);
+}
+
+//==============================================================================
+
+DataStore::DataStoreExporterWorker * BiosignalmlDataStoreExporter::workerInstance(DataStore::DataStoreData *pDataStoreData)
+{
+    // Return an instance of our worker
+
+    return new BiosignalmlDataStoreExporterWorker(pDataStoreData);
 }
 
 //==============================================================================

--- a/src/plugins/dataStore/BioSignalMLDataStore/src/biosignalmldatastoreexporter.h
+++ b/src/plugins/dataStore/BioSignalMLDataStore/src/biosignalmldatastoreexporter.h
@@ -34,14 +34,25 @@ namespace BioSignalMLDataStore {
 
 //==============================================================================
 
-class BiosignalmlDataStoreExporter : public DataStore::DataStoreExporter
+class BiosignalmlDataStoreExporterWorker : public DataStore::DataStoreExporterWorker
 {
     Q_OBJECT
 
 public:
-    explicit BiosignalmlDataStoreExporter(DataStore::DataStoreData *pDataStoreData);
+    explicit BiosignalmlDataStoreExporterWorker(DataStore::DataStoreData *pDataStoreData);
 
-    void execute(QString &pErrorMessage) const override;
+public slots:
+    void run() override;
+};
+
+//==============================================================================
+
+class BiosignalmlDataStoreExporter : public DataStore::DataStoreExporter
+{
+    Q_OBJECT
+
+protected:
+    DataStore::DataStoreExporterWorker * workerInstance(DataStore::DataStoreData *pDataStoreData) override;
 };
 
 //==============================================================================

--- a/src/plugins/dataStore/BioSignalMLDataStore/src/biosignalmldatastoreplugin.cpp
+++ b/src/plugins/dataStore/BioSignalMLDataStore/src/biosignalmldatastoreplugin.cpp
@@ -100,11 +100,14 @@ DataStore::DataStoreData * BioSignalMLDataStorePlugin::getData(const QString &pF
 
 //==============================================================================
 
-DataStore::DataStoreExporter * BioSignalMLDataStorePlugin::dataStoreExporterInstance(DataStore::DataStoreData *pDataStoreData) const
+DataStore::DataStoreExporter * BioSignalMLDataStorePlugin::dataStoreExporterInstance() const
 {
-    // Return an instance of our BioSignalML data store exporter
+    // Return the 'global' instance of our BioSignalML data store exporter
 
-    return new BiosignalmlDataStoreExporter(pDataStoreData);
+    static BiosignalmlDataStoreExporter instance;
+
+    return static_cast<BiosignalmlDataStoreExporter *>(Core::globalInstance("OpenCOR::BioSignalMLDataStore::BiosignalmlDataStoreExporter::instance()",
+                                                                            &instance));
 }
 
 //==============================================================================

--- a/src/plugins/dataStore/CSVDataStore/i18n/CSVDataStore_fr.ts
+++ b/src/plugins/dataStore/CSVDataStore/i18n/CSVDataStore_fr.ts
@@ -17,7 +17,7 @@
     </message>
 </context>
 <context>
-    <name>OpenCOR::CSVDataStore::CsvDataStoreExporter</name>
+    <name>OpenCOR::CSVDataStore::CsvDataStoreExporterWorker</name>
     <message>
         <source>The data could not be exported to CSV.</source>
         <translation>Les données n&apos;ont pas pu être exportées vers CSV.</translation>

--- a/src/plugins/dataStore/CSVDataStore/src/csvdatastoreexporter.cpp
+++ b/src/plugins/dataStore/CSVDataStore/src/csvdatastoreexporter.cpp
@@ -36,14 +36,14 @@ namespace CSVDataStore {
 
 //==============================================================================
 
-CsvDataStoreExporter::CsvDataStoreExporter(DataStore::DataStoreData *pDataStoreData) :
-    DataStore::DataStoreExporter(pDataStoreData)
+CsvDataStoreExporterWorker::CsvDataStoreExporterWorker(DataStore::DataStoreData *pDataStoreData) :
+    DataStore::DataStoreExporterWorker(pDataStoreData)
 {
 }
 
 //==============================================================================
 
-void CsvDataStoreExporter::execute(QString &pErrorMessage) const
+void CsvDataStoreExporterWorker::run()
 {
     // Do the export itself
     // Note: we would normally rely on a string to which we would append our
@@ -55,6 +55,7 @@ void CsvDataStoreExporter::execute(QString &pErrorMessage) const
     //       first write our header and then our data, one row at a time...
 
     QFile file(Core::temporaryFileName());
+    QString errorMessage = QString();
 
     if (file.open(QIODevice::WriteOnly)) {
         // Determine whether we need to export the VOI and, if so, remove it
@@ -218,11 +219,24 @@ void CsvDataStoreExporter::execute(QString &pErrorMessage) const
         if (!res) {
             file.remove();
 
-            pErrorMessage = tr("The data could not be exported to CSV.");
+            errorMessage = tr("The data could not be exported to CSV.");
         }
     } else {
-        pErrorMessage = tr("The CSV file could not be created.");
+        errorMessage = tr("The CSV file could not be created.");
     }
+
+    // Let people know that our XSL transformation has been performed
+
+    emit done(errorMessage);
+}
+
+//==============================================================================
+
+DataStore::DataStoreExporterWorker * CsvDataStoreExporter::workerInstance(DataStore::DataStoreData *pDataStoreData)
+{
+    // Return an instance of our worker
+
+    return new CsvDataStoreExporterWorker(pDataStoreData);
 }
 
 //==============================================================================

--- a/src/plugins/dataStore/CSVDataStore/src/csvdatastoreexporter.h
+++ b/src/plugins/dataStore/CSVDataStore/src/csvdatastoreexporter.h
@@ -34,14 +34,25 @@ namespace CSVDataStore {
 
 //==============================================================================
 
-class CsvDataStoreExporter : public DataStore::DataStoreExporter
+class CsvDataStoreExporterWorker : public DataStore::DataStoreExporterWorker
 {
     Q_OBJECT
 
 public:
-    explicit CsvDataStoreExporter(DataStore::DataStoreData *pDataStoreData);
+    explicit CsvDataStoreExporterWorker(DataStore::DataStoreData *pDataStoreData);
 
-    void execute(QString &pErrorMessage) const override;
+public slots:
+    void run() override;
+};
+
+//==============================================================================
+
+class CsvDataStoreExporter : public DataStore::DataStoreExporter
+{
+    Q_OBJECT
+
+protected:
+    DataStore::DataStoreExporterWorker * workerInstance(DataStore::DataStoreData *pDataStoreData) override;
 };
 
 //==============================================================================

--- a/src/plugins/dataStore/CSVDataStore/src/csvdatastoreplugin.cpp
+++ b/src/plugins/dataStore/CSVDataStore/src/csvdatastoreplugin.cpp
@@ -96,11 +96,14 @@ DataStore::DataStoreData * CSVDataStorePlugin::getData(const QString &pFileName,
 
 //==============================================================================
 
-DataStore::DataStoreExporter * CSVDataStorePlugin::dataStoreExporterInstance(DataStore::DataStoreData *pDataStoreData) const
+DataStore::DataStoreExporter * CSVDataStorePlugin::dataStoreExporterInstance() const
 {
-    // Return an instance of our CSV data store exporter
+    // Return the 'global' instance of our CSV data store exporter
 
-    return new CsvDataStoreExporter(pDataStoreData);
+    static CsvDataStoreExporter instance;
+
+    return static_cast<CsvDataStoreExporter *>(Core::globalInstance("OpenCOR::CSVDataStore::CsvDataStoreExporter::instance()",
+                                                                    &instance));
 }
 
 //==============================================================================

--- a/src/plugins/datastoreinterface.h
+++ b/src/plugins/datastoreinterface.h
@@ -169,20 +169,12 @@ private:
 
 //==============================================================================
 
-class DataStoreExporter : public QObject
+class DataStoreExporterWorker : public QObject
 {
     Q_OBJECT
 
 public:
-    explicit DataStoreExporter(DataStoreData *pDataStoreData);
-    ~DataStoreExporter() override;
-
-    void start();
-
-    virtual void execute(QString &pErrorMessage) const = 0;
-
-private:
-    QThread *mThread;
+    explicit DataStoreExporterWorker(DataStoreData *pDataStoreData);
 
 protected:
     DataStoreData *mDataStoreData;
@@ -191,8 +183,25 @@ signals:
     void progress(double pProgress);
     void done(const QString &pErrorMessage);
 
-private slots:
-    void started();
+public slots:
+   virtual void run() = 0;
+};
+
+//==============================================================================
+
+class DataStoreExporter : public QObject
+{
+    Q_OBJECT
+
+public:
+    void exportData(DataStoreData *pDataStoreData);
+
+protected:
+    virtual DataStoreExporterWorker * workerInstance(DataStoreData *pDataStoreData) = 0;
+
+signals:
+    void progress(double pProgress);
+    void done(const QString &pErrorMessage);
 };
 
 //==============================================================================

--- a/src/plugins/datastoreinterface.h
+++ b/src/plugins/datastoreinterface.h
@@ -188,8 +188,8 @@ protected:
     DataStoreData *mDataStoreData;
 
 signals:
+    void progress(double pProgress);
     void done(const QString &pErrorMessage);
-    void progress(double pProgress) const;
 
 private slots:
     void started();

--- a/src/plugins/datastoreinterface.inl
+++ b/src/plugins/datastoreinterface.inl
@@ -36,7 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                DataStore::DataStore *pDataStore,
                                                const QMap<int, QIcon> &pIcons) const PURE;
 
-    virtual DataStore::DataStoreExporter * dataStoreExporterInstance(DataStore::DataStoreData *pDataStoreData) const PURE;
+    virtual DataStore::DataStoreExporter * dataStoreExporterInstance() const PURE;
 
 #undef PURE
 

--- a/src/plugins/miscellaneous/Core/src/mathmlconverter.cpp
+++ b/src/plugins/miscellaneous/Core/src/mathmlconverter.cpp
@@ -47,11 +47,9 @@ MathmlConverter::MathmlConverter()
 
 MathmlConverter::~MathmlConverter()
 {
-    // Stop our XSL transformer
-    // Note: we don't need to delete it since it will be done as part of its
-    //       thread being stopped...
+    // Delete our XSL transformer
 
-    mXslTransformer->stop();
+    delete mXslTransformer;
 }
 
 //==============================================================================

--- a/src/plugins/miscellaneous/Core/src/xsltransformer.cpp
+++ b/src/plugins/miscellaneous/Core/src/xsltransformer.cpp
@@ -36,8 +36,8 @@ namespace Core {
 
 //==============================================================================
 
-XslTransformerJob::XslTransformerJob(const QString &pInput,
-                                     const QString &pXsl) :
+XslTransformerWorker::XslTransformerWorker(const QString &pInput,
+                                           const QString &pXsl) :
     mInput(pInput),
     mXsl(pXsl)
 {
@@ -45,92 +45,7 @@ XslTransformerJob::XslTransformerJob(const QString &pInput,
 
 //==============================================================================
 
-QString XslTransformerJob::input() const
-{
-    // Return our input
-
-    return mInput;
-}
-
-//==============================================================================
-
-QString XslTransformerJob::xsl() const
-{
-    // Return our XSL
-
-    return mXsl;
-}
-
-//==============================================================================
-
-XslTransformer::XslTransformer() :
-    mPaused(false),
-    mStopped(false),
-    mJobs(QList<XslTransformerJob>())
-{
-    // Create our thread
-
-    mThread = new QThread();
-
-    // Move ourselves to our thread
-
-    moveToThread(mThread);
-
-    // Create a few connections
-
-    connect(mThread, &QThread::started,
-            this, &XslTransformer::started);
-
-    connect(mThread, &QThread::finished,
-            mThread, &QThread::deleteLater);
-    connect(mThread, &QThread::finished,
-            this, &XslTransformer::deleteLater);
-}
-
-//==============================================================================
-
-void XslTransformer::transform(const QString &pInput, const QString &pXsl)
-{
-    // Add a new job to our list
-
-    mJobsMutex.lock();
-        mJobs << XslTransformerJob(pInput, pXsl);
-    mJobsMutex.unlock();
-
-    // Start/resume our thread, if needed
-
-    if (!mThread->isRunning())
-        mThread->start();
-    else if (mPaused)
-        mPausedCondition.wakeOne();
-}
-
-//==============================================================================
-
-void XslTransformer::stop()
-{
-    // Shutdown our thread, if needed
-
-    if (mThread->isRunning()) {
-        // Ask our thread to stop
-
-        mStopped = true;
-
-        // Resume our thread, if needed
-
-        if (mPaused)
-            mPausedCondition.wakeOne();
-
-        // Ask our thread to quit and wait for it to do so
-
-        mThread->quit();
-        mThread->wait();
-    }
-}
-
-//==============================================================================
-
-void XslTransformer::started()
+void XslTransformerWorker::run()
 {
     // Create our XML query object
 
@@ -139,51 +54,46 @@ void XslTransformer::started()
 
     xmlQuery.setMessageHandler(&dummyMessageHandler);
 
-    // Do our XSL transformations
+    // Customise our XML query object
 
-    QMutex pausedMutex;
+    xmlQuery.setFocus(mInput);
+    xmlQuery.setQuery(mXsl);
 
-    while (!mStopped) {
-        // Carry out our different jobs
+    // Do the XSL transformation
 
-        while (mJobs.count() && !mStopped) {
-            // Retrieve the first job in our list
+    QString output;
 
-            mJobsMutex.lock();
-                XslTransformerJob job = mJobs.first();
+    if (!xmlQuery.evaluateTo(&output))
+        output = QString();
 
-                mJobs.removeFirst();
-            mJobsMutex.unlock();
+    // Let people know that an XSL transformation has been performed
 
-            // Customise our XML query object
+    emit done(mInput, output);
+}
 
-            xmlQuery.setFocus(job.input());
-            xmlQuery.setQuery(job.xsl());
+//==============================================================================
 
-            // Do the XSL transformation
+void XslTransformer::transform(const QString &pInput, const QString &pXsl)
+{
+    QThread *thread = new QThread();
+    XslTransformerWorker *worker = new XslTransformerWorker(pInput, pXsl);
 
-            QString output;
+    worker->moveToThread(thread);
 
-            if (!xmlQuery.evaluateTo(&output))
-                output = QString();
+    connect(thread, &QThread::started,
+            worker, &XslTransformerWorker::run);
 
-            // Let people know that an XSL transformation has been performed
+    connect(worker, &XslTransformerWorker::done,
+            this, &XslTransformer::done);
+    connect(worker, &XslTransformerWorker::done,
+            thread, &QThread::quit);
+    connect(worker, &XslTransformerWorker::done,
+            worker, &XslTransformerWorker::deleteLater);
 
-            emit done(job.input(), output);
-        }
+    connect(thread, &QThread::finished,
+            thread, &QThread::deleteLater);
 
-        // Pause ourselves, unless we have been asked to stop
-
-        if (!mStopped) {
-            mPaused = true;
-
-            pausedMutex.lock();
-                mPausedCondition.wait(&pausedMutex);
-            pausedMutex.unlock();
-
-            mPaused = false;
-        }
-    }
+    thread->start();
 }
 
 //==============================================================================

--- a/src/plugins/miscellaneous/Core/src/xsltransformer.cpp
+++ b/src/plugins/miscellaneous/Core/src/xsltransformer.cpp
@@ -66,7 +66,7 @@ void XslTransformerWorker::run()
     if (!xmlQuery.evaluateTo(&output))
         output = QString();
 
-    // Let people know that an XSL transformation has been performed
+    // Let people know that our XSL transformation has been performed
 
     emit done(mInput, output);
 }

--- a/src/plugins/miscellaneous/Core/src/xsltransformer.cpp
+++ b/src/plugins/miscellaneous/Core/src/xsltransformer.cpp
@@ -75,6 +75,8 @@ void XslTransformerWorker::run()
 
 void XslTransformer::transform(const QString &pInput, const QString &pXsl)
 {
+    // Create and move our worker to a thread
+
     QThread *thread = new QThread();
     XslTransformerWorker *worker = new XslTransformerWorker(pInput, pXsl);
 
@@ -92,6 +94,8 @@ void XslTransformer::transform(const QString &pInput, const QString &pXsl)
 
     connect(thread, &QThread::finished,
             thread, &QThread::deleteLater);
+
+    // Start our worker by starting the thread in which it is
 
     thread->start();
 }

--- a/src/plugins/miscellaneous/Core/src/xsltransformer.h
+++ b/src/plugins/miscellaneous/Core/src/xsltransformer.h
@@ -42,17 +42,17 @@ namespace Core {
 
 //==============================================================================
 
-class DummyMessageHandler;
-
-//==============================================================================
-
-class XslTransformerJob
+class XslTransformerWorker : public QObject
 {
-public:
-    explicit XslTransformerJob(const QString &pInput, const QString &pXsl);
+    Q_OBJECT
 
-    QString input() const;
-    QString xsl() const;
+public:
+    explicit XslTransformerWorker(const QString &pInput, const QString &pXsl);
+
+    void run();
+
+signals:
+    void done(const QString &pInput, const QString &pOutput);
 
 private:
     QString mInput;
@@ -66,29 +66,10 @@ class CORE_EXPORT XslTransformer : public QObject
     Q_OBJECT
 
 public:
-    explicit XslTransformer();
-
     void transform(const QString &pInput, const QString &pXsl);
-
-    void stop();
-
-private:
-    QThread *mThread;
-
-    bool mPaused;
-    bool mStopped;
-
-    QMutex mJobsMutex;
-
-    QWaitCondition mPausedCondition;
-
-    QList<XslTransformerJob> mJobs;
 
 signals:
     void done(const QString &pInput, const QString &pOutput);
-
-private slots:
-    void started();
 };
 
 //==============================================================================

--- a/src/plugins/miscellaneous/Core/src/xsltransformer.h
+++ b/src/plugins/miscellaneous/Core/src/xsltransformer.h
@@ -51,12 +51,12 @@ public:
 
     void run();
 
-signals:
-    void done(const QString &pInput, const QString &pOutput);
-
 private:
     QString mInput;
     QString mXsl;
+
+signals:
+    void done(const QString &pInput, const QString &pOutput);
 };
 
 //==============================================================================

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
@@ -136,6 +136,7 @@ SimulationExperimentViewSimulationWidget::SimulationExperimentViewSimulationWidg
             this, &SimulationExperimentViewSimulationWidget::simulationRunning);
     connect(mSimulation, &SimulationSupport::Simulation::paused,
             this, &SimulationExperimentViewSimulationWidget::simulationPaused);
+
     connect(mSimulation, &SimulationSupport::Simulation::done,
             this, &SimulationExperimentViewSimulationWidget::simulationDone);
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
@@ -3183,10 +3183,10 @@ void SimulationExperimentViewSimulationWidget::simulationResultsExport()
 
         DataStore::DataStoreExporter *dataStoreExporter = dataStoreInterface->dataStoreExporterInstance(dataStoreData);
 
-        connect(dataStoreExporter, &DataStore::DataStoreExporter::done,
-                this, &SimulationExperimentViewSimulationWidget::dataStoreExportDone);
         connect(dataStoreExporter, &DataStore::DataStoreExporter::progress,
                 this, &SimulationExperimentViewSimulationWidget::dataStoreExportProgress);
+        connect(dataStoreExporter, &DataStore::DataStoreExporter::done,
+                this, &SimulationExperimentViewSimulationWidget::dataStoreExportDone);
 
         dataStoreExporter->start();
     }
@@ -4074,6 +4074,15 @@ void SimulationExperimentViewSimulationWidget::plotAxesChanged()
 
 //==============================================================================
 
+void SimulationExperimentViewSimulationWidget::dataStoreExportProgress(double pProgress)
+{
+    // There has been some progress with our export, so update our busy widget
+
+    Core::centralWidget()->setBusyWidgetProgress(pProgress);
+}
+
+//==============================================================================
+
 void SimulationExperimentViewSimulationWidget::dataStoreExportDone(const QString &pErrorMessage)
 {
     // We are done with the export, so hide our busy widget
@@ -4086,15 +4095,6 @@ void SimulationExperimentViewSimulationWidget::dataStoreExportDone(const QString
         Core::warningMessageBox(tr("Simulation Results Export"),
                                 pErrorMessage);
     }
-}
-
-//==============================================================================
-
-void SimulationExperimentViewSimulationWidget::dataStoreExportProgress(double pProgress)
-{
-    // There has been some progress with our export, so update our busy widget
-
-    Core::centralWidget()->setBusyWidgetProgress(pProgress);
 }
 
 //==============================================================================

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
@@ -136,8 +136,8 @@ SimulationExperimentViewSimulationWidget::SimulationExperimentViewSimulationWidg
             this, &SimulationExperimentViewSimulationWidget::simulationRunning);
     connect(mSimulation, &SimulationSupport::Simulation::paused,
             this, &SimulationExperimentViewSimulationWidget::simulationPaused);
-    connect(mSimulation, &SimulationSupport::Simulation::stopped,
-            this, &SimulationExperimentViewSimulationWidget::simulationStopped);
+    connect(mSimulation, &SimulationSupport::Simulation::done,
+            this, &SimulationExperimentViewSimulationWidget::simulationDone);
 
     connect(mSimulation, &SimulationSupport::Simulation::error,
             this, QOverload<const QString &>::of(&SimulationExperimentViewSimulationWidget::simulationError));
@@ -3248,7 +3248,7 @@ void SimulationExperimentViewSimulationWidget::simulationPaused()
 
 //==============================================================================
 
-void SimulationExperimentViewSimulationWidget::simulationStopped(qint64 pElapsedTime)
+void SimulationExperimentViewSimulationWidget::simulationDone(qint64 pElapsedTime)
 {
     // Output the given elapsed time, if valid
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
@@ -3181,14 +3181,14 @@ void SimulationExperimentViewSimulationWidget::simulationResultsExport()
 
         Core::centralWidget()->showProgressBusyWidget();
 
-        DataStore::DataStoreExporter *dataStoreExporter = dataStoreInterface->dataStoreExporterInstance(dataStoreData);
+        DataStore::DataStoreExporter *dataStoreExporter = dataStoreInterface->dataStoreExporterInstance();
 
         connect(dataStoreExporter, &DataStore::DataStoreExporter::progress,
                 this, &SimulationExperimentViewSimulationWidget::dataStoreExportProgress);
         connect(dataStoreExporter, &DataStore::DataStoreExporter::done,
                 this, &SimulationExperimentViewSimulationWidget::dataStoreExportDone);
 
-        dataStoreExporter->start();
+        dataStoreExporter->exportData(dataStoreData);
     }
 }
 

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.h
@@ -336,7 +336,8 @@ private slots:
 
     void simulationRunning(bool pIsResuming);
     void simulationPaused();
-    void simulationStopped(qint64 pElapsedTime);
+
+    void simulationDone(qint64 pElapsedTime);
 
     void resetProgressBar();
     void resetFileTabIcon();

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.h
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.h
@@ -366,8 +366,8 @@ private slots:
 
     void plotAxesChanged();
 
-    void dataStoreExportDone(const QString &pErrorMessage);
     void dataStoreExportProgress(double pProgress);
+    void dataStoreExportDone(const QString &pErrorMessage);
 
     void checkSimulationProperties();
     void checkSolversProperties();

--- a/src/plugins/support/SimulationSupport/i18n/SimulationSupport_fr.ts
+++ b/src/plugins/support/SimulationSupport/i18n/SimulationSupport_fr.ts
@@ -11,9 +11,5 @@
         <source>the starting point cannot be greater than the ending point</source>
         <translation>le point de départ ne peut pas être plus grand que le point d&apos;arrivée</translation>
     </message>
-    <message>
-        <source>the simulation worker could not be created</source>
-        <translation>l&apos;agent de simulation n&apos;a pas pu être créé</translation>
-    </message>
 </context>
 </TS>

--- a/src/plugins/support/SimulationSupport/src/simulation.cpp
+++ b/src/plugins/support/SimulationSupport/src/simulation.cpp
@@ -812,8 +812,7 @@ double * SimulationResults::algebraic(int pIndex, int pRun) const
 Simulation::Simulation(const QString &pFileName) :
     mFileName(pFileName),
     mRuntime(nullptr),
-    mWorker(nullptr),
-    mWorkerFinishedEventLoop(new QEventLoop())
+    mWorker(nullptr)
 {
     // Retrieve our file details
 
@@ -1139,11 +1138,6 @@ void Simulation::run()
         connect(mWorker, &SimulationWorker::error,
                 this, &Simulation::error);
 
-        // Track of when our worker is finished
-
-        connect(mWorker, &SimulationWorker::finished,
-                mWorkerFinishedEventLoop, &QEventLoop::quit);
-
         // Start our worker
 
         mWorker->run();
@@ -1174,10 +1168,10 @@ void Simulation::resume()
 
 void Simulation::stop()
 {
-    // Stop our worker, if any, and wait for it to be done
+    // Stop our worker
 
-    if (mWorker && mWorker->stop())
-        mWorkerFinishedEventLoop->exec();
+    if (mWorker)
+        mWorker->stop();
 }
 
 //==============================================================================

--- a/src/plugins/support/SimulationSupport/src/simulation.cpp
+++ b/src/plugins/support/SimulationSupport/src/simulation.cpp
@@ -1111,30 +1111,20 @@ quint64 Simulation::size()
 
 //==============================================================================
 
-bool Simulation::run()
+void Simulation::run()
 {
+    // Make sure that we have a runtime
+
     if (!mRuntime)
-        return false;
+        return;
 
-    // Initialise our worker, if not active
+    // Initialise our worker, if we don't already have one and if the
+    // simulation settings we were given are sound
 
-    if (mWorker) {
-        return false;
-    } else {
-        // Make sure that the simulation settings we were given are sound
-
-        if (!simulationSettingsOk())
-            return false;
-
+    if (!mWorker && simulationSettingsOk()) {
         // Create our worker
 
         mWorker = new SimulationWorker(this, mWorker);
-
-        if (!mWorker) {
-            emit error(tr("the simulation worker could not be created"));
-
-            return false;
-        }
 
         // Create a few connections
 
@@ -1156,46 +1146,43 @@ bool Simulation::run()
 
         // Start our worker
 
-        return mWorker->run();
+        mWorker->run();
     }
 }
 
 //==============================================================================
 
-bool Simulation::pause()
+void Simulation::pause()
 {
     // Pause our worker
 
-    return mWorker?mWorker->pause():false;
+    if (mWorker)
+        mWorker->pause();
 }
 
 //==============================================================================
 
-bool Simulation::resume()
+void Simulation::resume()
 {
     // Resume our worker
 
-    return mWorker?mWorker->resume():false;
+    if (mWorker)
+        mWorker->resume();
 }
 
 //==============================================================================
 
-bool Simulation::stop()
+void Simulation::stop()
 {
     // Stop our worker, if any, and wait for it to be done
 
-    if (mWorker && mWorker->stop()) {
+    if (mWorker && mWorker->stop())
         mWorkerFinishedEventLoop->exec();
-
-        return true;
-    } else {
-        return false;
-    }
 }
 
 //==============================================================================
 
-bool Simulation::reset(bool pAll)
+void Simulation::reset(bool pAll)
 {
     // Reset our data
 
@@ -1203,7 +1190,8 @@ bool Simulation::reset(bool pAll)
 
     // Reset our worker
 
-    return mWorker?mWorker->reset():false;
+    if (mWorker)
+        mWorker->reset();
 }
 
 //==============================================================================

--- a/src/plugins/support/SimulationSupport/src/simulation.cpp
+++ b/src/plugins/support/SimulationSupport/src/simulation.cpp
@@ -1132,8 +1132,8 @@ void Simulation::run()
         connect(mWorker, &SimulationWorker::paused,
                 this, &Simulation::paused);
 
-        connect(mWorker, &SimulationWorker::finished,
-                this, &Simulation::stopped);
+        connect(mWorker, &SimulationWorker::done,
+                this, &Simulation::done);
 
         connect(mWorker, &SimulationWorker::error,
                 this, &Simulation::error);

--- a/src/plugins/support/SimulationSupport/src/simulation.h
+++ b/src/plugins/support/SimulationSupport/src/simulation.h
@@ -262,12 +262,12 @@ public:
 
     quint64 size();
 
-    bool run();
-    bool pause();
-    bool resume();
-    bool stop();
+    void run();
+    void pause();
+    void resume();
+    void stop();
 
-    bool reset(bool pAll = true);
+    void reset(bool pAll = true);
 
 private:
     QString mFileName;

--- a/src/plugins/support/SimulationSupport/src/simulation.h
+++ b/src/plugins/support/SimulationSupport/src/simulation.h
@@ -31,10 +31,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //==============================================================================
 
-class QEventLoop;
-
-//==============================================================================
-
 namespace OpenCOR {
 
 //==============================================================================
@@ -284,8 +280,6 @@ private:
 
     SimulationData *mData;
     SimulationResults *mResults;
-
-    QEventLoop *mWorkerFinishedEventLoop;
 
     void retrieveFileDetails(bool pRecreateRuntime = true);
 

--- a/src/plugins/support/SimulationSupport/src/simulation.h
+++ b/src/plugins/support/SimulationSupport/src/simulation.h
@@ -288,7 +288,8 @@ private:
 signals:
     void running(bool pIsResuming);
     void paused();
-    void stopped(qint64 pElapsedTime);
+
+    void done(qint64 pElapsedTime);
 
     void error(const QString &pMessage);
 };

--- a/src/plugins/support/SimulationSupport/src/simulationworker.cpp
+++ b/src/plugins/support/SimulationSupport/src/simulationworker.cpp
@@ -152,19 +152,12 @@ void SimulationWorker::stop()
 
 //==============================================================================
 
-bool SimulationWorker::reset()
+void SimulationWorker::reset()
 {
-    // Check that we are either running or paused
+    // Stop ourselves, if we are currently running or paused
 
-    if (isRunning() || isPaused()) {
-        // Ask ourselves to reinitialise our solver
-
+    if (isRunning() || isPaused())
         mReset = true;
-
-        return true;
-    } else {
-        return false;
-    }
 }
 
 //==============================================================================

--- a/src/plugins/support/SimulationSupport/src/simulationworker.cpp
+++ b/src/plugins/support/SimulationSupport/src/simulationworker.cpp
@@ -84,50 +84,6 @@ double SimulationWorker::currentPoint() const
 
 //==============================================================================
 
-void SimulationWorker::pause()
-{
-    // Pause ourselves, if we are currently running
-
-    if (isRunning())
-        mPaused = true;
-}
-
-//==============================================================================
-
-void SimulationWorker::resume()
-{
-    // Resume ourselves, if we are currently paused
-
-    if (isPaused())
-        mPausedCondition.wakeOne();
-}
-
-//==============================================================================
-
-void SimulationWorker::stop()
-{
-    // Stop ourselves, if we are currently running or paused
-
-    if (isRunning() || isPaused()) {
-        mStopped = true;
-
-        if (isPaused())
-            mPausedCondition.wakeOne();
-    }
-}
-
-//==============================================================================
-
-void SimulationWorker::reset()
-{
-    // Stop ourselves, if we are currently running or paused
-
-    if (isRunning() || isPaused())
-        mReset = true;
-}
-
-//==============================================================================
-
 void SimulationWorker::run()
 {
     // Let people know that we are running
@@ -320,6 +276,50 @@ void SimulationWorker::run()
     // Let people know that we are done and give them the elapsed time
 
     emit done(mError?-1:elapsedTime);
+}
+
+//==============================================================================
+
+void SimulationWorker::pause()
+{
+    // Pause ourselves, if we are currently running
+
+    if (isRunning())
+        mPaused = true;
+}
+
+//==============================================================================
+
+void SimulationWorker::resume()
+{
+    // Resume ourselves, if we are currently paused
+
+    if (isPaused())
+        mPausedCondition.wakeOne();
+}
+
+//==============================================================================
+
+void SimulationWorker::stop()
+{
+    // Stop ourselves, if we are currently running or paused
+
+    if (isRunning() || isPaused()) {
+        mStopped = true;
+
+        if (isPaused())
+            mPausedCondition.wakeOne();
+    }
+}
+
+//==============================================================================
+
+void SimulationWorker::reset()
+{
+    // Stop ourselves, if we are currently running or paused
+
+    if (isRunning() || isPaused())
+        mReset = true;
 }
 
 //==============================================================================

--- a/src/plugins/support/SimulationSupport/src/simulationworker.cpp
+++ b/src/plugins/support/SimulationSupport/src/simulationworker.cpp
@@ -63,7 +63,7 @@ SimulationWorker::SimulationWorker(Simulation *pSimulation,
     connect(mThread, &QThread::started,
             this, &SimulationWorker::started);
 
-    connect(this, &SimulationWorker::finished,
+    connect(this, &SimulationWorker::done,
             mThread, &QThread::quit);
 
     connect(mThread, &QThread::finished,
@@ -353,7 +353,7 @@ void SimulationWorker::started()
 
     // Let people know that we are done and give them the elapsed time
 
-    emit finished(mError?-1:elapsedTime);
+    emit done(mError?-1:elapsedTime);
 }
 
 //==============================================================================

--- a/src/plugins/support/SimulationSupport/src/simulationworker.cpp
+++ b/src/plugins/support/SimulationSupport/src/simulationworker.cpp
@@ -52,7 +52,7 @@ SimulationWorker::SimulationWorker(Simulation *pSimulation,
 {
     // Create our thread
 
-    mThread = new MyThread();
+    mThread = new QThread();
 
     // Move ourselves to our thread
 

--- a/src/plugins/support/SimulationSupport/src/simulationworker.cpp
+++ b/src/plugins/support/SimulationSupport/src/simulationworker.cpp
@@ -346,7 +346,7 @@ void SimulationWorker::started()
 
     // Reset our simulation owner's knowledge of us
     // Note: if we were to do it the Qt way, our simulation owner would have a
-    //       slot for our finished() signal, but we want our simulation owner to
+    //       slot for our done() signal, but we want our simulation owner to
     //       know as quickly as possible that we are done...
 
     mSelf = nullptr;

--- a/src/plugins/support/SimulationSupport/src/simulationworker.cpp
+++ b/src/plugins/support/SimulationSupport/src/simulationworker.cpp
@@ -52,7 +52,7 @@ SimulationWorker::SimulationWorker(Simulation *pSimulation,
 {
     // Create our thread
 
-    mThread = new QThread();
+    mThread = new MyThread();
 
     // Move ourselves to our thread
 

--- a/src/plugins/support/SimulationSupport/src/simulationworker.cpp
+++ b/src/plugins/support/SimulationSupport/src/simulationworker.cpp
@@ -103,65 +103,42 @@ double SimulationWorker::currentPoint() const
 
 //==============================================================================
 
-bool SimulationWorker::run()
+void SimulationWorker::run()
 {
-    // Start our thread, but only if we are not already running
+    // Start our thread, if we are not already running
 
-    if (!mThread->isRunning()) {
+    if (!mThread->isRunning())
         mThread->start();
-
-        return true;
-    } else {
-        return false;
-    }
 }
 
 //==============================================================================
 
-bool SimulationWorker::pause()
+void SimulationWorker::pause()
 {
-    // Pause ourselves, but only if we are currently running
+    // Pause ourselves, if we are currently running
 
-    if (isRunning()) {
-        // Ask ourselves to pause
-
+    if (isRunning())
         mPaused = true;
-
-        return true;
-    } else {
-        return false;
-    }
 }
 
 //==============================================================================
 
-bool SimulationWorker::resume()
+void SimulationWorker::resume()
 {
-    // Resume ourselves, but only if are currently paused
+    // Resume ourselves, if we are currently paused
 
-    if (isPaused()) {
-        // Ask ourselves to resume
-
+    if (isPaused())
         mPausedCondition.wakeOne();
-
-        return true;
-    } else {
-        return false;
-    }
 }
 
 //==============================================================================
 
-bool SimulationWorker::stop()
+void SimulationWorker::stop()
 {
-    // Check that we are either running or paused
+    // Stop ourselves, if we are currently running or paused
 
     if (isRunning() || isPaused()) {
-        // Ask our thread to stop
-
         mStopped = true;
-
-        // Resume our thread, if needed
 
         if (isPaused())
             mPausedCondition.wakeOne();
@@ -170,10 +147,6 @@ bool SimulationWorker::stop()
 
         mThread->quit();
         mThread->wait();
-
-        return true;
-    } else {
-        return false;
     }
 }
 

--- a/src/plugins/support/SimulationSupport/src/simulationworker.h
+++ b/src/plugins/support/SimulationSupport/src/simulationworker.h
@@ -28,7 +28,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QObject>
 #include <QWaitCondition>
 
-#include <QThread>
 //==============================================================================
 
 namespace OpenCOR {
@@ -48,12 +47,6 @@ namespace SimulationSupport {
 class Simulation;
 
 //==============================================================================
-class MyThread : public QThread
-{
-public:
-    explicit MyThread() { qDebug("[%p] MyThread CONSTRUCTOR...", this); }
-    ~MyThread() override { qDebug("[%p] MyThread DESTRUCTOR...", this); }
-};
 
 class SimulationWorker : public QObject
 {
@@ -76,7 +69,7 @@ public:
     bool reset();
 
 private:
-    MyThread *mThread;
+    QThread *mThread;
 
     Simulation *mSimulation;
 

--- a/src/plugins/support/SimulationSupport/src/simulationworker.h
+++ b/src/plugins/support/SimulationSupport/src/simulationworker.h
@@ -53,7 +53,7 @@ class SimulationWorker : public QObject
     Q_OBJECT
 
 public:
-    explicit SimulationWorker(Simulation *pSimulation,
+    explicit SimulationWorker(Simulation *pSimulation, QThread *pThread,
                               SimulationWorker *&pSelf);
 
     bool isRunning() const;
@@ -61,7 +61,6 @@ public:
 
     double currentPoint() const;
 
-    void run();
     void pause();
     void resume();
     void stop();
@@ -69,9 +68,9 @@ public:
     void reset();
 
 private:
-    QThread *mThread;
-
     Simulation *mSimulation;
+
+    QThread *mThread;
 
     CellMLSupport::CellmlFileRuntime *mRuntime;
 
@@ -96,9 +95,10 @@ signals:
 
     void error(const QString &pMessage);
 
-private slots:
-    void started();
+public slots:
+    void run();
 
+private slots:
     void emitError(const QString &pMessage);
 };
 

--- a/src/plugins/support/SimulationSupport/src/simulationworker.h
+++ b/src/plugins/support/SimulationSupport/src/simulationworker.h
@@ -66,7 +66,7 @@ public:
     void resume();
     void stop();
 
-    bool reset();
+    void reset();
 
 private:
     QThread *mThread;

--- a/src/plugins/support/SimulationSupport/src/simulationworker.h
+++ b/src/plugins/support/SimulationSupport/src/simulationworker.h
@@ -61,10 +61,10 @@ public:
 
     double currentPoint() const;
 
-    bool run();
-    bool pause();
-    bool resume();
-    bool stop();
+    void run();
+    void pause();
+    void resume();
+    void stop();
 
     bool reset();
 

--- a/src/plugins/support/SimulationSupport/src/simulationworker.h
+++ b/src/plugins/support/SimulationSupport/src/simulationworker.h
@@ -28,6 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QObject>
 #include <QWaitCondition>
 
+#include <QThread>
 //==============================================================================
 
 namespace OpenCOR {
@@ -47,6 +48,12 @@ namespace SimulationSupport {
 class Simulation;
 
 //==============================================================================
+class MyThread : public QThread
+{
+public:
+    explicit MyThread() { qDebug("[%p] MyThread CONSTRUCTOR...", this); }
+    ~MyThread() override { qDebug("[%p] MyThread DESTRUCTOR...", this); }
+};
 
 class SimulationWorker : public QObject
 {
@@ -69,7 +76,7 @@ public:
     bool reset();
 
 private:
-    QThread *mThread;
+    MyThread *mThread;
 
     Simulation *mSimulation;
 

--- a/src/plugins/support/SimulationSupport/src/simulationworker.h
+++ b/src/plugins/support/SimulationSupport/src/simulationworker.h
@@ -92,7 +92,7 @@ signals:
     void running(bool pIsResuming);
     void paused();
 
-    void finished(qint64 pElapsedTime);
+    void done(qint64 pElapsedTime);
 
     void error(const QString &pMessage);
 


### PR DESCRIPTION
Indeed, we used to have some connections that were supposed to get a worker to be deleteLater()ed, but they never were (e.g. DataStoreExporter::~DataStoreExporter() was never being called, hence leaking memory). I believe this was because deleteLater() was actually called from the wrong thread and therefore never executed as such (as per the Qt documentation).