### PR TITLE
Tab Bar widget: make sure we delete our style on macOS

### DIFF
--- a/src/plugins/miscellaneous/Core/src/tabbarwidget.cpp
+++ b/src/plugins/miscellaneous/Core/src/tabbarwidget.cpp
@@ -78,6 +78,17 @@ TabBarWidget::TabBarWidget(QWidget *pParent) :
 
 //==============================================================================
 
+TabBarWidget::~TabBarWidget()
+{
+    // Delete some internal objects
+
+#ifdef Q_OS_MAC
+    delete style();
+#endif
+}
+
+//==============================================================================
+
 int TabBarWidget::oldIndex() const
 {
     // Return our old index

--- a/src/plugins/miscellaneous/Core/src/tabbarwidget.h
+++ b/src/plugins/miscellaneous/Core/src/tabbarwidget.h
@@ -44,6 +44,7 @@ class CORE_EXPORT TabBarWidget : public QTabBar
 
 public:
     explicit TabBarWidget(QWidget *pParent);
+    ~TabBarWidget() override;
 
     int oldIndex() const;
     void setOldIndex(int pOldIndex);


### PR DESCRIPTION
Indeed, when calling QWidget::setStyle(), the ownership of the style
object is not transferred, so we must therefore delete it ourselves.