### PR TITLE
Some minor cleaning up

### DIFF
--- a/src/plugins/dataStore/BioSignalMLDataStore/src/biosignalmldatastoreimporter.cpp
+++ b/src/plugins/dataStore/BioSignalMLDataStore/src/biosignalmldatastoreimporter.cpp
@@ -50,7 +50,7 @@ void BiosignalmlDataStoreImporterWorker::run()
     try {
         // Retrieve our clock and determine our number of data points
 
-        bsml::HDF5::Recording *recording = new bsml::HDF5::Recording(mImportData->fileName().toStdString());
+        bsml::HDF5::Recording *recording = new bsml::HDF5::Recording(mImportData->fileName().toStdString(), true);
         std::vector<double> clockTicks = recording->get_clock(recording->get_clock_uris().front())->read();
 
         // Retrieve the values of our different variables

--- a/src/plugins/dataStore/BioSignalMLDataStore/src/biosignalmldatastoreplugin.cpp
+++ b/src/plugins/dataStore/BioSignalMLDataStore/src/biosignalmldatastoreplugin.cpp
@@ -91,7 +91,7 @@ DataStore::DataStoreImportData * BioSignalMLDataStorePlugin::getImportData(const
     DataStore::DataStoreImportData *res = nullptr;
 
     try {
-        bsml::HDF5::Recording *recording = new bsml::HDF5::Recording(pFileName.toStdString());
+        bsml::HDF5::Recording *recording = new bsml::HDF5::Recording(pFileName.toStdString(), true);
         res = new DataStore::DataStoreImportData(pFileName, pImportDataStore,
                                                  pResultsDataStore,
                                                  int(recording->get_signal_uris().size()),
@@ -181,7 +181,7 @@ bool BioSignalMLDataStorePlugin::isFile(const QString &pFileName) const
     bsml::HDF5::Recording *recording = nullptr;
 
     try {
-        recording = new bsml::HDF5::Recording(pFileName.toStdString());
+        recording = new bsml::HDF5::Recording(pFileName.toStdString(), true);
     } catch (...) {
         // Something went wrong, so clearly not a BioSignalML file
 

--- a/src/plugins/editing/CellMLTextView/src/cellmltextviewwidget.cpp
+++ b/src/plugins/editing/CellMLTextView/src/cellmltextviewwidget.cpp
@@ -743,8 +743,8 @@ bool CellmlTextViewWidget::isEditorWidgetContentsModified(const QString &pFileNa
 
     if (data) {
         if (Core::FileManager::instance()->isModified(pFileName)) {
-            // The given file is considered as modified, so we need to retrieve
-            // the contents of its physical version
+            // The given file is considered modified, so we need to retrieve the
+            // contents of its physical version
 
             QString fileContents;
 
@@ -771,8 +771,8 @@ bool CellmlTextViewWidget::isEditorWidgetContentsModified(const QString &pFileNa
 
             return Core::sha1(data->editingWidget()->editorWidget()->contents()).compare(Core::sha1(data->convertedFileContents()));
         } else {
-            // The given file is not considered as modified, so simply compare
-            // the SHA-1 value of our editor's contents with our internal one
+            // The given file is not considered modified, so simply compare the
+            // SHA-1 value of our editor's contents with our internal one
 
             return Core::sha1(data->editingWidget()->editorWidget()->contents()).compare(data->sha1());
         }

--- a/src/plugins/miscellaneous/Core/src/file.cpp
+++ b/src/plugins/miscellaneous/Core/src/file.cpp
@@ -194,7 +194,7 @@ bool File::isDifferent(const QString &pFileContents) const
 {
     // Return whether we are different from the given file contents by comparing
     // our respective SHA-1 values
-    // Note: if we are considered as modified, then we want to compare the given
+    // Note: if we are considered modified, then we want to compare the given
     //       file contents against our corresponding physical version otherwise
     //       our internal SHA-1 value...
 
@@ -286,7 +286,7 @@ bool File::setModified(bool pModified)
         // Note: indeed, say that you are editing a file in the Raw Text view
         //       and that the file gets modified outside of OpenCOR and that you
         //       decline reloading it. In that case, the file will be rightly
-        //       considered as modified. Then, if you modify it so that it now
+        //       considered modified. Then, if you modify it so that it now
         //       corresponds to the physical version of the file, the Raw Text
         //       view will update the modified state of the file, but the SHA-1
         //       value will be out-of-date, hence we need to update it...

--- a/src/plugins/support/StandardSupport/src/standardfilemanager.cpp
+++ b/src/plugins/support/StandardSupport/src/standardfilemanager.cpp
@@ -57,12 +57,6 @@ StandardFileManager::StandardFileManager() :
 
 //==============================================================================
 
-StandardFileManager::~StandardFileManager()
-{
-}
-
-//==============================================================================
-
 bool StandardFileManager::isFile(const QString &pFileName, bool pForceChecking) const
 {
     // If the given file is already managed, then we consider that it's of the

--- a/src/plugins/support/StandardSupport/src/standardfilemanager.h
+++ b/src/plugins/support/StandardSupport/src/standardfilemanager.h
@@ -53,7 +53,6 @@ protected:
     QMap<QString, StandardFile *> mFiles;
 
     explicit StandardFileManager();
-    ~StandardFileManager() override;
 
     virtual bool canLoad(const QString &pFileName) const = 0;
 


### PR DESCRIPTION
This is particularly import for BioSignalMLDataStorePlugin::isFile()
since calling bsml::HDF5::Recording() in read-write mode will
eventually result in the BioSignalML file being modified (when we
delete the recording). In turn, this means that its SHA-1 value will be
different, resulting in OpenCOR telling us that the BioSignalML file
has been modified while it actually hasn’t been.