### PR TITLE
Always pass QDomElement objects by reference

### DIFF
--- a/src/plugins/miscellaneous/Core/src/corecliutils.cpp
+++ b/src/plugins/miscellaneous/Core/src/corecliutils.cpp
@@ -50,7 +50,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QStringList>
 #include <QTemporaryDir>
 #include <QTemporaryFile>
-#include <QTextStream>
 #include <QXmlSchema>
 #include <QXmlSchemaValidator>
 #include <QXmlStreamReader>
@@ -955,9 +954,7 @@ QByteArray serialiseDomDocument(const QDomDocument &pDomDocument)
 
     // Serialise our 'reduced' DOM document
 
-    QTextStream textStream(&res, QIODevice::WriteOnly);
-
-    domDocument.save(textStream, 4);
+    res = domDocument.toByteArray(4);
 
     // Manually serialise the elements' attributes
 

--- a/src/plugins/miscellaneous/Core/src/corecliutils.cpp
+++ b/src/plugins/miscellaneous/Core/src/corecliutils.cpp
@@ -574,7 +574,7 @@ QString formatXml(const QString &pXml)
 
 //==============================================================================
 
-void cleanContentMathml(QDomElement pDomElement)
+void cleanContentMathml(QDomElement &pDomElement)
 {
     // Clean up the current element
     // Note: the idea is to remove all the attributes that are not in the
@@ -611,7 +611,10 @@ QString cleanContentMathml(const QString &pContentMathml)
     QDomDocument domDocument;
 
     if (domDocument.setContent(pContentMathml, true)) {
-        cleanContentMathml(domDocument.documentElement());
+        for (QDomElement childElement = domDocument.firstChildElement();
+             !childElement.isNull(); childElement = childElement.nextSiblingElement()) {
+            cleanContentMathml(childElement);
+        }
 
         return domDocument.toString(-1);
     } else {
@@ -621,7 +624,7 @@ QString cleanContentMathml(const QString &pContentMathml)
 
 //==============================================================================
 
-void cleanPresentationMathml(QDomElement pDomElement)
+void cleanPresentationMathml(QDomElement &pDomElement)
 {
     // Merge successive child mrow elements, as long as their parent is not an
     // element that requires a specific number of arguments (which could become
@@ -707,7 +710,10 @@ QString cleanPresentationMathml(const QString &pPresentationMathml)
     QDomDocument domDocument;
 
     if (domDocument.setContent(pPresentationMathml)) {
-        cleanPresentationMathml(domDocument.documentElement());
+        for (QDomElement childElement = domDocument.firstChildElement();
+             !childElement.isNull(); childElement = childElement.nextSiblingElement()) {
+            cleanPresentationMathml(childElement);
+        }
 
         return domDocument.toString(-1);
     } else {

--- a/src/plugins/support/COMBINESupport/src/combinearchive.cpp
+++ b/src/plugins/support/COMBINESupport/src/combinearchive.cpp
@@ -30,7 +30,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QFile>
 #include <QRegularExpression>
 #include <QTemporaryDir>
-#include <QTextStream>
 
 //==============================================================================
 


### PR DESCRIPTION
This adds a bit more code, but it prevents shallow copies, so it ought
to be slightly faster, which cannot be a bad thing.