### PR TITLE
libSEDML: removed our use of an explicit release tag (#2042)

### DIFF
--- a/src/plugins/thirdParty/libSEDML/CMakeLists.txt
+++ b/src/plugins/thirdParty/libSEDML/CMakeLists.txt
@@ -14,10 +14,9 @@ set(LIBRARY_VERSION ${MAJOR_LIBRARY_VERSION}.4.4)
 
 set(GIT_TAG 0.4.4)
 
-# Package repository and release tag
+# Package repository
 
 set(PACKAGE_REPOSITORY libSEDML)
-SET(RELEASE_TAG 0.4.4)
 
 # Specify where our local package will be installed
 
@@ -66,7 +65,6 @@ if(USE_PREBUILT_LIBSEDML_PACKAGE)
             retrieve_package_file(${PACKAGE_NAME} ${PACKAGE_VERSION}
                                   ${RELATIVE_PROJECT_SOURCE_DIR} 18fc2673869ca6f40d3cb6e17aec123a2dccca37
                                   PACKAGE_REPOSITORY ${PACKAGE_REPOSITORY}
-                                  RELEASE_TAG ${RELEASE_TAG}
                                   SHA1_FILES ${SHA1_FILES}
                                   SHA1_VALUES 7ab5c523e8eb1e11f6ef865526ffbdd5ed01beea
                                               404fd98fef8cabea7757f60d9de9eb6672fe006a)
@@ -74,7 +72,6 @@ if(USE_PREBUILT_LIBSEDML_PACKAGE)
             retrieve_package_file(${PACKAGE_NAME} ${PACKAGE_VERSION}
                                   ${RELATIVE_PROJECT_SOURCE_DIR} 98dd0a19f02a45f2e164d9e2090db7fe29e3a5e2
                                   PACKAGE_REPOSITORY ${PACKAGE_REPOSITORY}
-                                  RELEASE_TAG ${RELEASE_TAG}
                                   SHA1_FILES ${SHA1_FILES}
                                   SHA1_VALUES af5d225115778e213f6577d4fa2b9364196c51d6
                                               404fd98fef8cabea7757f60d9de9eb6672fe006a)
@@ -83,14 +80,12 @@ if(USE_PREBUILT_LIBSEDML_PACKAGE)
         retrieve_package_file(${PACKAGE_NAME} ${PACKAGE_VERSION}
                               ${RELATIVE_PROJECT_SOURCE_DIR} 7be2e5c00149b3351d03d3ba26194125493c9e66
                               PACKAGE_REPOSITORY ${PACKAGE_REPOSITORY}
-                              RELEASE_TAG ${RELEASE_TAG}
                               SHA1_FILES ${SHA1_FILES}
                               SHA1_VALUES f1fb831e5cf1f3ddc7d674c2ab832f91cc9c38ab)
     else()
         retrieve_package_file(${PACKAGE_NAME} ${PACKAGE_VERSION}
                               ${RELATIVE_PROJECT_SOURCE_DIR} 5c8c9681b5f76e6eefa4e345d28fae297df9e80e
                               PACKAGE_REPOSITORY ${PACKAGE_REPOSITORY}
-                              RELEASE_TAG ${RELEASE_TAG}
                               SHA1_FILES ${SHA1_FILES}
                               SHA1_VALUES 730ac3c50ce494a29b454d1e050f2b9b6dc81952)
     endif()
@@ -184,7 +179,6 @@ else()
     create_package_file(${PACKAGE_NAME} ${PACKAGE_VERSION}
                         ${LOCAL_EXTERNAL_PACKAGE_DIR}
                         PACKAGE_REPOSITORY ${PACKAGE_REPOSITORY}
-                        RELEASE_TAG ${RELEASE_TAG}
                         PACKAGED_FILES include ${SHA1_FILES}
                         SHA1_FILES ${SHA1_FILES}
                         TARGET ${PACKAGE_BUILD})


### PR DESCRIPTION
The release tag used to be `0.4.4`, which required our use of an
explicit release tag since by default we would expect the release tag
to be `v0.4.4`. However, a new `v0.4.4` release tag has been created on
GitHub, hence now we don’t need to specify an explicit release tag.