### PR TITLE
Uses out latest libgit2 to correctly link zlib.

### DIFF
--- a/src/plugins/thirdParty/libgit2/CMakeLists.txt
+++ b/src/plugins/thirdParty/libgit2/CMakeLists.txt
@@ -13,11 +13,11 @@ set(LIBRARY_VERSION ${MAJOR_LIBRARY_VERSION}.${MINOR_LIBRARY_VERSION}.1)
 
 # Git tag for our library
 
-set(GIT_TAG v0.28.1-opencor)
+set(GIT_TAG v0.28.1-opencor-2)
 
 # Release tag
 
-set(RELEASE_TAG v0.28.1-opencor)
+set(RELEASE_TAG v0.28.1-opencor-2)
 
 # Specify where our local package will be installed
 

--- a/src/plugins/thirdParty/libgit2/CMakeLists.txt
+++ b/src/plugins/thirdParty/libgit2/CMakeLists.txt
@@ -137,7 +137,8 @@ else()
             -DUSE_HTTPS=OpenSSL
             -DUSE_SSH=OFF
             -DWINHTTP=OFF
-            -DZLIB_ROOT=${ZLIB_ROOT_DIR}
+            -DZLIB_INCLUDE_DIR=${ZLIB_INCLUDE_DIR}
+            -DZLIB_LIBRARY=${ZLIB_LIBRARY}
         BUILD_BYPRODUCTS
             <INSTALL_DIR>/lib/${IMPORT_LIBRARY}
     )


### PR DESCRIPTION
Fixes issue #2088.

The issue with linking the system OpenSSL libraries instead of our libraries disappeared once the libgit2 package was rebuilt. I suspect some previous version of CMake's FindOpenSSL package ignored our OPENSSL settings... 