### PR TITLE
read mesh correctly BUT without using reset

### DIFF
--- a/src/plugins/editing/CellMLZincMappingView/src/cellmlzincmappingviewzincwidget.cpp
+++ b/src/plugins/editing/CellMLZincMappingView/src/cellmlzincmappingviewzincwidget.cpp
@@ -96,13 +96,13 @@ void CellMLZincMappingViewZincWidget::changeSource(const QString &pMainFileName)
     mMainFileName = pMainFileName;
     initAuxFile();
 
-    OpenCMISS::Zinc::Region region = mZincContext.createRegion();
-    mZincContext.setDefaultRegion(region);
+    //TODO the emit launched by reset make opencor crashing
+    //reset();
+
+    setup();
 
     setupRegion();
 
-    //mSceneViewer.setScene(region.getScene());
-    //draw();
     initializeGL();
     draw();
 }


### PR DESCRIPTION
using zincwidget::reset() create a crash just after..., so it work without it