### PR TITLE
KaTeX: upgrade to version 0.13.5 (#2468)

### DIFF
--- a/doc/downloads/index.js
+++ b/doc/downloads/index.js
@@ -37,7 +37,8 @@ var jsonData = { "versions": [
                        }
                      ],
                      "changes": [
-                       { "change": "<strong>Python Console window:</strong> automatically reload imported modules (see issue <a href=\"https://github.com/opencor/opencor/issues/2466\">#2466</a>)." }
+                       { "change": "<strong>Python Console window:</strong> automatically reload imported modules (see issue <a href=\"https://github.com/opencor/opencor/issues/2466\">#2466</a>)." },
+                       { "change": "<strong>Third-party libraries:</strong> upgraded <a href=\"https://katex.org/\">KaTeX</a> to version 0.13.5 (see issue <a href=\"https://github.com/opencor/opencor/issues/2468\">#2468</a>)." }
                      ]
                    },
                    { "major": 0, "minor": 5, "patch": 0, "day": 15, "month": 10, "year": 2016, "type": 0, "license": 1,


### PR DESCRIPTION
Closes #2468.