### PR TITLE
CellML tools: e-notation based numbers don't get properly exported from CellML 1.1 to CellML 1.0 (#2479)

### DIFF
--- a/doc/downloads/index.js
+++ b/doc/downloads/index.js
@@ -37,7 +37,8 @@ var jsonData = { "versions": [
                        }
                      ],
                      "changes": [
-                       { "change": "<strong>Simulation Experiment view:</strong> make sure that we can (once again) export a <a href=\"https://cellml.org/\">CellML</a> 1.1 model to a <a href=\"https://co.mbine.org/documents/archive\">COMBINE archive</a> on Windows (see issue <a href=\"https://github.com/opencor/opencor/issues/2478\">#2478</a>)." }
+                      { "change": "<strong>CellML tools:</strong> e-notation based numbers now get properly exported from <a href=\"https://cellml.org/\">CellML</a> 1.1 to <a href=\"https://cellml.org/\">CellML</a> 1.0 (see issue <a href=\"https://github.com/opencor/opencor/issues/2479\">#2479</a>)." },
+                      { "change": "<strong>Simulation Experiment view:</strong> make sure that we can (once again) export a <a href=\"https://cellml.org/\">CellML</a> 1.1 model to a <a href=\"https://co.mbine.org/documents/archive\">COMBINE archive</a> on Windows (see issue <a href=\"https://github.com/opencor/opencor/issues/2478\">#2478</a>)." }
                      ]
                    },
                    { "major": 0, "minor": 5, "patch": 0, "day": 15, "month": 10, "year": 2016, "type": 0, "license": 1,

--- a/doc/whatIsNew.js
+++ b/doc/whatIsNew.js
@@ -88,7 +88,8 @@ var jsonData = { "versions": [
                          "entries": [
                            { "type": "subCategory", "name": "CellML tools",
                              "entries": [
-                               { "type": "added", "description": "Validation of a <a href=\"https://cellml.org/\">CellML</a> file from the <a href=\"https://en.wikipedia.org/wiki/Command-line_interface\">CLI</a>." }
+                               { "type": "added", "description": "Validation of a <a href=\"https://cellml.org/\">CellML</a> file from the <a href=\"https://en.wikipedia.org/wiki/Command-line_interface\">CLI</a>." },
+                               { "type": "fixed", "description": "Export of a <a href=\"https://cellml.org/\">CellML</a> 1.1 model with e-notation based numbers to <a href=\"https://cellml.org/\">CellML</a> 1.0." }
                              ]
                            }
                          ]

--- a/src/plugins/support/CellMLSupport/src/cellmlfilecellml10exporter.cpp
+++ b/src/plugins/support/CellMLSupport/src/cellmlfilecellml10exporter.cpp
@@ -707,18 +707,24 @@ bool CellmlFileCellml10Exporter::saveModel(iface::cellml_api::Model *pModel,
 {
     // Save the given model or ouput it to the console, if no file name has been
     // provided, and this after having reformatted the given model
+    // Note: for some reasons, the MathML type of e-notation based numbers gets
+    //       moved to the CellML namespace, so we revert that behaviour...
 
     QDomDocument domDocument;
 
     domDocument.setContent(QString::fromStdWString(pModel->serialisedText()));
 
+    QByteArray serialisedDomDocument = Core::serialiseDomDocument(domDocument);
+
+    serialisedDomDocument.replace("cellml:type=\"e-notation\"", "type=\"e-notation\"");
+
     if (pFileName.isEmpty()) {
-        std::cout << QString(Core::serialiseDomDocument(domDocument)).toStdString() << std::endl;
+        std::cout << QString(serialisedDomDocument).toStdString() << std::endl;
 
         return true;
     }
 
-    return Core::writeFile(pFileName, Core::serialiseDomDocument(domDocument));
+    return Core::writeFile(pFileName, serialisedDomDocument);
 }
 
 //==============================================================================

--- a/src/plugins/support/CellMLSupport/tests/tests.cpp
+++ b/src/plugins/support/CellMLSupport/tests/tests.cpp
@@ -39,7 +39,7 @@ void Tests::runtimeTest(const QString &pFileName, const QString &pCellmlVersion,
                         const QStringList &pModelParameters, bool pIsValid)
 {
     // Get a CellML file object for the given CellML file and make sure that it
-    // is considered of the expected CellML version
+    // is considered to be of the expected CellML version
 
     OpenCOR::CellMLSupport::CellmlFile cellmlFile(pFileName);
 
@@ -105,7 +105,7 @@ void Tests::runtimeTests()
     //    directly visible);
     //  - A 'new' version of a bond graph model implementation where the
     //    VOI is now visible in the main CellML file (as well as some other
-    //    model parameters); and
+    //    model parameters);
     //  - A model (Noble 1962) that imports its units (and no components) from a
     //    child model; and
     //  - A somewhat comprehensive model (Faville 2008).

--- a/src/plugins/tools/CellMLTools/tests/data/e_notation.cellml
+++ b/src/plugins/tools/CellMLTools/tests/data/e_notation.cellml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<model name="e_notation" xmlns="http://www.cellml.org/cellml/1.1#" xmlns:cellml="http://www.cellml.org/cellml/1.1#">
+    <component name="main">
+        <variable name="x" units="dimensionless"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>x</ci>
+                <cn cellml:units="dimensionless" type="e-notation">6.948<sep/>-6</cn>
+            </apply>
+        </math>
+    </component>
+</model>

--- a/src/plugins/tools/CellMLTools/tests/data/e_notation_export.out
+++ b/src/plugins/tools/CellMLTools/tests/data/e_notation_export.out
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<model name="e_notation" xmlns="http://www.cellml.org/cellml/1.0#">
+    <component name="main">
+        <variable name="x" units="dimensionless"/>
+        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+            <apply>
+                <eq/>
+                <ci>x</ci>
+                <cn type="e-notation" cellml:units="dimensionless">6.948<sep/>-6</cn>
+            </apply>
+        </math>
+    </component>
+</model>

--- a/src/plugins/tools/CellMLTools/tests/tests.cpp
+++ b/src/plugins/tools/CellMLTools/tests/tests.cpp
@@ -102,6 +102,13 @@ void Tests::exportToCellml10Tests()
     QVERIFY(!OpenCOR::runCli({ "-c", "CellMLTools::export", fileName, "cellml_1_0" }, mOutput));
     QCOMPARE(mOutput, OpenCOR::fileContents(OpenCOR::fileName("src/plugins/tools/CellMLTools/tests/data/cellml_1_0_export.out")) << QString());
 
+    // Export a CellML 1.1 file with an e-notation number to CellML 1.0
+
+    fileName = OpenCOR::fileName("src/plugins/tools/CellMLTools/tests/data/e_notation.cellml");
+
+    QVERIFY(!OpenCOR::runCli({ "-c", "CellMLTools::export", fileName, "cellml_1_0" }, mOutput));
+    QCOMPARE(mOutput, OpenCOR::fileContents(OpenCOR::fileName("src/plugins/tools/CellMLTools/tests/data/e_notation_export.out")) << QString());
+
     // Try to export a non-existing CellML file to CellML 1.0
 
     QVERIFY(OpenCOR::runCli({ "-c", "CellMLTools::export", "non_existing_file", "cellml_1_0" }, mOutput));


### PR DESCRIPTION
Fixes #2479.