### PR TITLE
CellML tools: fixed an issue with namespaces in a `math` element following the export of a CellML 1.1 model to CellML 1.0

### DIFF
--- a/doc/downloads/index.js
+++ b/doc/downloads/index.js
@@ -38,7 +38,7 @@ var jsonData = { "versions": [
                      ],
                      "changes": [
                       { "change": "<strong>General:</strong> improved the <a href=\"https://en.wikipedia.org/wiki/Microsoft_Windows\">Windows</a> installer (see issue <a href=\"https://github.com/opencor/opencor/issues/2561\">#2561</a>)." }
-                    ]
+                     ]
                    },
                    { "major": 0, "minor": 5, "patch": 0, "day": 15, "month": 10, "year": 2016, "type": 0, "license": 1,
                      "platforms": [

--- a/doc/downloads/index.js
+++ b/doc/downloads/index.js
@@ -37,7 +37,8 @@ var jsonData = { "versions": [
                        }
                      ],
                      "changes": [
-                      { "change": "<strong>General:</strong> improved the <a href=\"https://en.wikipedia.org/wiki/Microsoft_Windows\">Windows</a> installer (see issue <a href=\"https://github.com/opencor/opencor/issues/2561\">#2561</a>)." }
+                      { "change": "<strong>General:</strong> improved the <a href=\"https://en.wikipedia.org/wiki/Microsoft_Windows\">Windows</a> installer (see issue <a href=\"https://github.com/opencor/opencor/issues/2561\">#2561</a>)." },
+                      { "change": "<strong>CellML tools:</strong> fixed an issue with namespaces in a <code>math</code> element following the export of a <a href=\"https://cellml.org/\">CellML</a> 1.1 model to <a href=\"https://cellml.org/\">CellML</a> 1.0 (see issue <a href=\"https://github.com/opencor/opencor/issues/2564\">#2564</a>)." },
                      ]
                    },
                    { "major": 0, "minor": 5, "patch": 0, "day": 15, "month": 10, "year": 2016, "type": 0, "license": 1,

--- a/doc/downloads/previousSnapshots.js
+++ b/doc/downloads/previousSnapshots.js
@@ -23,7 +23,7 @@ var jsonData = { "versions": [
                       { "change": "<strong>CellML tools:</strong> can now directly export to <a href=\"https://en.wikipedia.org/wiki/C_(programming_language)\">C</a>, <a href=\"https://en.wikipedia.org/wiki/Fortran#FORTRAN_77\">FORTRAN 77</a>, <a href=\"https://en.wikipedia.org/wiki/MATLAB\">MATLAB</a>, and <a href=\"https://en.wikipedia.org/wiki/Python_(programming_language)\">Python</a> (see issues <a href=\"https://github.com/opencor/opencor/issues/129\">#129</a>, <a href=\"https://github.com/opencor/opencor/issues/131\">#131</a>, <a href=\"https://github.com/opencor/opencor/issues/128\">#128</a>, and <a href=\"https://github.com/opencor/opencor/issues/132\">#132</a> respectively)." },
                       { "change": "<strong>Simulation Experiment view:</strong> can now fully reload a remote SED-ML file (see issue <a href=\"https://github.com/opencor/opencor/issues/2550\">#2550</a>)." },
                       { "change": "<strong>Third-party libraries:</strong> upgraded <a href=\"https://openssl.org/\">OpenSSL</a> to version 1.1.1l (see issue <a href=\"https://github.com/opencor/opencor/issues/2532\">#2532</a>)." }
-                    ]
+                     ]
                    },
                    { "major": 0, "minor": 0, "patch": 0, "day": 19, "month": 8, "year": 2021, "type": 2, "license": 2,
                      "platforms": [
@@ -50,7 +50,7 @@ var jsonData = { "versions": [
                       { "change": "<strong>Simulation support:</strong> prevent <a href=\"https://python.org/\">Python</a> scripts from hanging up the Simulation Experiment view and crashing OpenCOR upon exiting (see issue <a href=\"https://github.com/opencor/opencor/issues/2528\">#2528</a>)." },
                       { "change": "<strong>Simulation Experiment view:</strong> added a way to plot a parameter against the last used parameter (see issue <a href=\"https://github.com/opencor/opencor/issues/2521\">#2521</a>)." },
                       { "change": "<strong>Third-party libraries:</strong> upgraded <a href=\"https://llvm.org/\">LLVM</a>+<a href=\"https://clang.llvm.org/\">Clang</a> to version 12.0.1 (see issue <a href=\"https://github.com/opencor/opencor/issues/2515\">#2515</a>). Upgraded <a href=\"http://qwt.sourceforge.net/\">Qwt</a> to version 6.2.0 (see issue <a href=\"https://github.com/opencor/opencor/issues/2517\">#2517</a>). Upgraded <a href=\"https://katex.org/\">KaTeX</a> to version 0.13.13 (see issue <a href=\"https://github.com/opencor/opencor/issues/2524\">#2524</a>). Upgraded <a href=\"https://libgit2.github.com/\">libgit2</a> to version 1.1.1 (see issue <a href=\"https://github.com/opencor/opencor/issues/2534\">#2534</a>). Upgraded <a href=\"https://mesa3d.org/\">Mesa</a> to version 21.2.0 (see issue <a href=\"https://github.com/opencor/opencor/issues/2536\">#2536</a>). Upgraded <a href=\"https://packages.ubuntu.com/impish/oxygen-icon-theme\">Oxygen</a> to version 5.85.0 (see issue <a href=\"https://github.com/opencor/opencor/issues/2537\">#2537</a>)." }
-                    ]
+                     ]
                    },
                    { "major": 0, "minor": 0, "patch": 0, "day": 9, "month": 7, "year": 2021, "type": 2, "license": 2,
                      "platforms": [
@@ -76,7 +76,7 @@ var jsonData = { "versions": [
                       { "change": "<strong>CellML Text view:</strong> improved support for piecewise statements (see issue <a href=\"https://github.com/opencor/opencor/issues/575\">#575</a>)." },
                       { "change": "<strong>Simulation Experiment view:</strong> prevent a potential crash on <a href=\"https://en.wikipedia.org/wiki/Microsoft_Windows\">Windows</a> when clearing all simulation results (see issue <a href=\"https://github.com/opencor/opencor/issues/2497\">#2497</a>). Prevent random crashes when reloading a file (see issue <a href=\"https://github.com/opencor/opencor/issues/2510\">#2510</a>)." },
                       { "change": "<strong>Third-party libraries:</strong> upgraded <a href=\"http://qwt.sourceforge.net/\">Qwt</a> to version 6.1.6 (see issue <a href=\"https://github.com/opencor/opencor/issues/2483\">#2483</a>). Upgraded <a href=\"https://katex.org/\">KaTeX</a> to version 0.13.11 (see issue <a href=\"https://github.com/opencor/opencor/issues/2504\">#2504</a>). Upgraded <a href=\"https://riverbankcomputing.com/software/qscintilla/intro\">QScintilla</a> to version 2.13.0 (see issue <a href=\"https://github.com/opencor/opencor/issues/2503\">#2503</a>)." }
-                    ]
+                     ]
                    },
                    { "major": 0, "minor": 0, "patch": 0, "day": 19, "month": 5, "year": 2021, "type": 2, "license": 2,
                      "platforms": [

--- a/doc/whatIsNew.js
+++ b/doc/whatIsNew.js
@@ -99,7 +99,8 @@ var jsonData = { "versions": [
                              "entries": [
                                { "type": "added", "description": "Validation of a <a href=\"https://cellml.org/\">CellML</a> file from the <a href=\"https://en.wikipedia.org/wiki/Command-line_interface\">CLI</a>." },
                                { "type": "added", "description": "Direct way to export to <a href=\"https://en.wikipedia.org/wiki/C_(programming_language)\">C</a>, <a href=\"https://en.wikipedia.org/wiki/Fortran#FORTRAN_77\">FORTRAN 77</a>, <a href=\"https://en.wikipedia.org/wiki/MATLAB\">MATLAB</a>, and <a href=\"https://en.wikipedia.org/wiki/Python_(programming_language)\">Python</a>." },
-                               { "type": "fixed", "description": "Export of a <a href=\"https://cellml.org/\">CellML</a> 1.1 model with e-notation based numbers to <a href=\"https://cellml.org/\">CellML</a> 1.0." }
+                               { "type": "fixed", "description": "Export of a <a href=\"https://cellml.org/\">CellML</a> 1.1 model with e-notation based numbers to <a href=\"https://cellml.org/\">CellML</a> 1.0." },
+                               { "type": "fixed", "description": "Namespaces in a <code>math</code> element following the export of a <a href=\"https://cellml.org/\">CellML</a> 1.1 model to <a href=\"https://cellml.org/\">CellML</a> 1.0." }
                              ]
                            }
                          ]

--- a/src/plugins/support/CellMLSupport/src/cellmlfilecellml10exporter.cpp
+++ b/src/plugins/support/CellMLSupport/src/cellmlfilecellml10exporter.cpp
@@ -716,6 +716,7 @@ bool CellmlFileCellml10Exporter::saveModel(iface::cellml_api::Model *pModel,
 
     QByteArray serialisedDomDocument = Core::serialiseDomDocument(domDocument);
 
+    serialisedDomDocument.replace(" cellml:xmlns=\"http://www.w3.org/1998/Math/MathML\"", "");
     serialisedDomDocument.replace("cellml:type=\"e-notation\"", "type=\"e-notation\"");
 
     if (pFileName.isEmpty()) {

--- a/src/plugins/tools/CellMLTools/tests/data/cellml_1_0_export.out
+++ b/src/plugins/tools/CellMLTools/tests/data/cellml_1_0_export.out
@@ -81,7 +81,7 @@
         <variable name="gleak_max" private_interface="out" public_interface="in" units="mS_per_cmsq"/>
         <variable name="Cm" private_interface="out" public_interface="in" units="uF_per_cmsq"/>
         <variable name="time" private_interface="out" public_interface="in" units="ms"/>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply cmeta:id="V_calculation" xmlns:cmeta="http://www.cellml.org/cellml/1.0#">
                 <eq/>
                 <apply>
@@ -107,7 +107,7 @@
                 </apply>
             </apply>
         </math>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply cmeta:id="minus_V_calculation" xmlns:cmeta="http://www.cellml.org/cellml/1.0#">
                 <eq/>
                 <ci>minus_V</ci>
@@ -124,7 +124,7 @@
         <variable name="stimPeriod" public_interface="in" units="ms"/>
         <variable name="stimDuration" public_interface="in" units="ms"/>
         <variable name="stimCurrent" public_interface="in" units="uA_per_cmsq"/>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply cmeta:id="stimulus_calculation" xmlns:cmeta="http://www.cellml.org/cellml/1.0#">
                 <eq/>
                 <ci>IStim</ci>
@@ -177,7 +177,7 @@
         <variable name="VNa" private_interface="out" public_interface="in" units="mV"/>
         <variable name="gNa" private_interface="out" public_interface="out" units="mS_per_cmsq"/>
         <variable name="gNa_max" private_interface="out" public_interface="in" units="mS_per_cmsq"/>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply cmeta:id="INa_calculation" xmlns:cmeta="http://www.cellml.org/cellml/1.0#">
                 <eq/>
                 <ci>INa</ci>
@@ -192,7 +192,7 @@
                 </apply>
             </apply>
         </math>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply cmeta:id="gNa_calculation" xmlns:cmeta="http://www.cellml.org/cellml/1.0#">
                 <eq/>
                 <ci>gNa</ci>
@@ -218,7 +218,7 @@
         <variable name="VK" private_interface="out" public_interface="in" units="mV"/>
         <variable name="gK" private_interface="out" public_interface="out" units="mS_per_cmsq"/>
         <variable name="gK_max" private_interface="out" public_interface="in" units="mS_per_cmsq"/>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply cmeta:id="IK_calculation" xmlns:cmeta="http://www.cellml.org/cellml/1.0#">
                 <eq/>
                 <ci>IK</ci>
@@ -233,7 +233,7 @@
                 </apply>
             </apply>
         </math>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply cmeta:id="gK_calculation" xmlns:cmeta="http://www.cellml.org/cellml/1.0#">
                 <eq/>
                 <ci>gK</ci>
@@ -254,7 +254,7 @@
         <variable name="V" private_interface="out" public_interface="in" units="mV"/>
         <variable name="Vleak" private_interface="out" public_interface="in" units="mV"/>
         <variable name="gleak_max" private_interface="out" public_interface="in" units="mS_per_cmsq"/>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply cmeta:id="Ileak_calculation" xmlns:cmeta="http://www.cellml.org/cellml/1.0#">
                 <eq/>
                 <ci>Ileak</ci>
@@ -273,7 +273,7 @@
     <component name="alpha_m">
         <variable name="alpha" private_interface="out" public_interface="out" units="per_ms"/>
         <variable name="V" private_interface="out" public_interface="in" units="mV"/>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply cmeta:id="alpha_m_calculation" xmlns:cmeta="http://www.cellml.org/cellml/1.0#">
                 <eq/>
                 <ci>alpha</ci>
@@ -311,7 +311,7 @@
     <component name="beta_m">
         <variable name="beta" private_interface="out" public_interface="out" units="per_ms"/>
         <variable name="V" private_interface="out" public_interface="in" units="mV"/>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply cmeta:id="beta_m_calculation" xmlns:cmeta="http://www.cellml.org/cellml/1.0#">
                 <eq/>
                 <ci>beta</ci>
@@ -333,7 +333,7 @@
     <component name="alpha_h">
         <variable name="alpha" private_interface="out" public_interface="out" units="per_ms"/>
         <variable name="V" private_interface="out" public_interface="in" units="mV"/>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply cmeta:id="alpha_h_calculation" xmlns:cmeta="http://www.cellml.org/cellml/1.0#">
                 <eq/>
                 <ci>alpha</ci>
@@ -355,7 +355,7 @@
     <component name="beta_h">
         <variable name="beta" private_interface="out" public_interface="out" units="per_ms"/>
         <variable name="V" private_interface="out" public_interface="in" units="mV"/>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply cmeta:id="beta_h_calculation" xmlns:cmeta="http://www.cellml.org/cellml/1.0#">
                 <eq/>
                 <ci>beta</ci>
@@ -388,7 +388,7 @@
         <variable name="X_initial" private_interface="out" public_interface="in" units="dimensionless"/>
         <variable name="alpha_X" private_interface="out" public_interface="in" units="per_ms"/>
         <variable name="beta_X" private_interface="out" public_interface="in" units="per_ms"/>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply>
                 <eq/>
                 <apply>
@@ -424,7 +424,7 @@
         <variable name="X_initial" private_interface="out" public_interface="in" units="dimensionless"/>
         <variable name="alpha_X" private_interface="out" public_interface="in" units="per_ms"/>
         <variable name="beta_X" private_interface="out" public_interface="in" units="per_ms"/>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply>
                 <eq/>
                 <apply>
@@ -457,7 +457,7 @@
     <component name="alpha_n">
         <variable name="alpha" private_interface="out" public_interface="out" units="per_ms"/>
         <variable name="V" private_interface="out" public_interface="in" units="mV"/>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply cmeta:id="alpha_n_calculation" xmlns:cmeta="http://www.cellml.org/cellml/1.0#">
                 <eq/>
                 <ci>alpha</ci>
@@ -495,7 +495,7 @@
     <component name="beta_n">
         <variable name="beta" private_interface="out" public_interface="out" units="per_ms"/>
         <variable name="V" private_interface="out" public_interface="in" units="mV"/>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply cmeta:id="beta_n_calculation" xmlns:cmeta="http://www.cellml.org/cellml/1.0#">
                 <eq/>
                 <ci>beta</ci>
@@ -520,7 +520,7 @@
         <variable name="X_initial" private_interface="out" public_interface="in" units="dimensionless"/>
         <variable name="alpha_X" private_interface="out" public_interface="in" units="per_ms"/>
         <variable name="beta_X" private_interface="out" public_interface="in" units="per_ms"/>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply>
                 <eq/>
                 <apply>

--- a/src/plugins/tools/CellMLTools/tests/data/e_notation_export.out
+++ b/src/plugins/tools/CellMLTools/tests/data/e_notation_export.out
@@ -2,7 +2,7 @@
 <model name="e_notation" xmlns="http://www.cellml.org/cellml/1.0#">
     <component name="main">
         <variable name="x" units="dimensionless"/>
-        <math cellml:xmlns="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+        <math xmlns="http://www.w3.org/1998/Math/MathML" xmlns:cellml="http://www.cellml.org/cellml/1.0#">
             <apply>
                 <eq/>
                 <ci>x</ci>


### PR DESCRIPTION
Fixes #2564.